### PR TITLE
DEBUG: ctxnew probe (do not merge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,8 +79,11 @@ config.status
 configure
 libtool
 such
+such_ts
 sendtx
+sendtx_ts
 spvnode
+spvnode_ts
 config/libdogecoin-config.h
 config/libdogecoin-config.h.in
 config/libdogecoin-config.h.in~
@@ -163,6 +166,9 @@ store/*
 !/src/optee/host/Makefile
 !/src/optee/ta/Makefile
 /src/optee/build
+
+# Out-of-tree build directories for the independent library/test/CLI builds
+build-*/
 
 # Node.js (snarkjs etc. for ZK helpers)
 node_modules/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,8 @@ IF(WITH_NET)
         file(COPY "${PROJECT_SOURCE_DIR}/src/libevent/include/event2" DESTINATION "${PROJECT_SOURCE_DIR}/include")
         find_path(LIBEVENT_INCLUDE_DIR event.h PATHS "${PROJECT_SOURCE_DIR}/include/event2" REQUIRED)
         find_path(LIBEVENT_INCLUDE_DIR event-config.h PATHS "${PROJECT_SOURCE_DIR}/include/event2" REQUIRED)
-        FIND_LIBRARY(LIBEVENT NAMES event event_core event_extras event_pthreads HINTS "${PROJECT_SOURCE_DIR}/src/libevent/build/lib/${CMAKE_BUILD_TYPE}" REQUIRED)
+        FIND_LIBRARY(LIBEVENT NAMES event HINTS "${PROJECT_SOURCE_DIR}/src/libevent/build/lib/${CMAKE_BUILD_TYPE}" REQUIRED)
+        SET(LIBEVENT_PTHREADS "")
         FIND_LIBRARY(WINPTHREADS NAMES pthreadVC2 pthreadwin32 pthreads pthread HINTS "${PROJECT_SOURCE_DIR}/contrib/winpthreads/include/lib/x64/" REQUIRED)
     ELSE()
         # build libevent
@@ -105,7 +106,8 @@ IF(WITH_NET)
         file(COPY "${PROJECT_SOURCE_DIR}/src/libevent/include/event2" DESTINATION "${PROJECT_SOURCE_DIR}/include")
         find_path(LIBEVENT_INCLUDE_DIR event.h PATHS "${PROJECT_SOURCE_DIR}/include/event2" REQUIRED)
         find_path(LIBEVENT_INCLUDE_DIR event-config.h PATHS "${PROJECT_SOURCE_DIR}/include/event2" REQUIRED)
-        FIND_LIBRARY(LIBEVENT NAMES event event_core event_extras event_pthreads HINTS "${PROJECT_SOURCE_DIR}/src/libevent/build/lib/${CMAKE_BUILD_TYPE}" REQUIRED)
+        FIND_LIBRARY(LIBEVENT NAMES event HINTS "${PROJECT_SOURCE_DIR}/src/libevent/build/lib/${CMAKE_BUILD_TYPE}" REQUIRED)
+        FIND_LIBRARY(LIBEVENT_PTHREADS NAMES event_pthreads HINTS "${PROJECT_SOURCE_DIR}/src/libevent/build/lib/${CMAKE_BUILD_TYPE}" REQUIRED)
     ENDIF()
 ENDIF()
 
@@ -374,6 +376,7 @@ TARGET_SOURCES(${LIBDOGECOIN_NAME} PRIVATE
     src/block.c
     src/buffer.c
     src/chacha20.c
+    src/context.c
     src/cstr.c
     src/ctaes.c
     src/ecc.c
@@ -534,6 +537,7 @@ IF(USE_TESTS)
         test/block_tests.c
         test/buffer_tests.c
         test/chacha20_tests.c
+        test/context_tests.c
         test/cstr_tests.c
         test/ecc_tests.c
         test/hash_tests.c
@@ -647,7 +651,7 @@ IF(WITH_NET)
     )
 
     IF(WIN32 AND USE_TPM2)
-        TARGET_LINK_LIBRARIES(${LIBS} ${LIBEVENT} ${LIBEVENT_PTHREADS} tbs ncrypt crypt32)
+        TARGET_LINK_LIBRARIES(${LIBS} ${LIBEVENT} tbs ncrypt crypt32)
     ELSEIF(USE_TSS2)
         TARGET_LINK_LIBRARIES(${LIBS} ${LIBEVENT} ${LIBEVENT_PTHREADS} ${LIBTSS2})
     ELSE()
@@ -680,19 +684,51 @@ IF(WITH_TOOLS)
     ENDIF()
     TARGET_INCLUDE_DIRECTORIES(such ${visibility} src)
 
+    # Thread-safe variant: same sources, DOGECOIN_TS routes through the `_ts`
+    # library APIs (see doc/thread_safety.md).
+    ADD_EXECUTABLE(such_ts src/cli/such.c)
+    INSTALL(TARGETS such_ts RUNTIME)
+    IF (WIN32 AND USE_TPM2)
+        TARGET_LINK_LIBRARIES(such_ts ${LIBS} tbs ncrypt crypt32)
+    ELSEIF (USE_TSS2)
+        TARGET_LINK_LIBRARIES(such_ts ${LIBS} ${LIBTSS2})
+    ELSE()
+        TARGET_LINK_LIBRARIES(such_ts ${LIBS})
+    ENDIF()
+    TARGET_INCLUDE_DIRECTORIES(such_ts ${visibility} src)
+    TARGET_COMPILE_DEFINITIONS(such_ts ${visibility} DOGECOIN_TS=1)
+
     IF(WITH_NET)
         ADD_EXECUTABLE(sendtx src/cli/sendtx.c)
         INSTALL(TARGETS sendtx RUNTIME)
         TARGET_LINK_LIBRARIES(sendtx ${LIBDOGECOIN_NAME})
         TARGET_INCLUDE_DIRECTORIES(sendtx ${visibility} src)
+
+        ADD_EXECUTABLE(sendtx_ts src/cli/sendtx.c)
+        INSTALL(TARGETS sendtx_ts RUNTIME)
+        TARGET_LINK_LIBRARIES(sendtx_ts ${LIBDOGECOIN_NAME})
+        TARGET_INCLUDE_DIRECTORIES(sendtx_ts ${visibility} src)
+        TARGET_COMPILE_DEFINITIONS(sendtx_ts ${visibility} DOGECOIN_TS=1)
+
         ADD_EXECUTABLE(spvnode src/cli/spvnode.c)
         INSTALL(TARGETS spvnode RUNTIME)
 
         IF (WIN32 AND USE_TPM2)
-            TARGET_LINK_LIBRARIES(spvnode ${LIBDOGECOIN_NAME} tbs ncrypt crypt32)
+            TARGET_LINK_LIBRARIES(spvnode ${LIBDOGECOIN_NAME} ${LIBEVENT} tbs ncrypt crypt32)
         ELSE()
-            TARGET_LINK_LIBRARIES(spvnode ${LIBDOGECOIN_NAME})
+            TARGET_LINK_LIBRARIES(spvnode ${LIBDOGECOIN_NAME} ${LIBEVENT} ${LIBEVENT_PTHREADS})
         ENDIF()
         TARGET_INCLUDE_DIRECTORIES(spvnode ${visibility} src)
+
+        ADD_EXECUTABLE(spvnode_ts src/cli/spvnode.c)
+        INSTALL(TARGETS spvnode_ts RUNTIME)
+
+        IF (WIN32 AND USE_TPM2)
+            TARGET_LINK_LIBRARIES(spvnode_ts ${LIBDOGECOIN_NAME} ${LIBEVENT} tbs ncrypt crypt32)
+        ELSE()
+            TARGET_LINK_LIBRARIES(spvnode_ts ${LIBDOGECOIN_NAME} ${LIBEVENT} ${LIBEVENT_PTHREADS})
+        ENDIF()
+        TARGET_INCLUDE_DIRECTORIES(spvnode_ts ${visibility} src)
+        TARGET_COMPILE_DEFINITIONS(spvnode_ts ${visibility} DOGECOIN_TS=1)
     ENDIF()
 ENDIF()

--- a/Makefile.am
+++ b/Makefile.am
@@ -72,6 +72,7 @@ noinst_HEADERS = \
     include/dogecoin/seal.h \
     include/dogecoin/sha2.h \
     include/dogecoin/smpv.h \
+    include/dogecoin/threadsafe.h \
     include/dogecoin/tool.h \
     include/dogecoin/transaction.h \
     include/dogecoin/tx.h \
@@ -98,6 +99,7 @@ libdogecoin_la_SOURCES = \
     src/block.c \
     src/buffer.c \
     src/chacha20.c \
+    src/context.c \
     src/chainparams.c \
     src/cstr.c \
     src/ctaes.c \
@@ -268,6 +270,7 @@ tests_SOURCES = \
     test/block_tests.c \
     test/buffer_tests.c \
     test/chacha20_tests.c \
+    test/context_tests.c \
     test/cstr_tests.c \
     test/ecc_tests.c \
     test/hash_tests.c \
@@ -434,6 +437,15 @@ such_CFLAGS = $(libdogecoin_la_CFLAGS)
 such_CPPFLAGS = -I$(top_srcdir)/src
 such_LDFLAGS = -static
 
+# Thread-safe variant: same sources compiled with DOGECOIN_TS so the CLI routes
+# through the thread-safe (`_ts`) library APIs. See doc/thread_safety.md.
+inst_PROGRAMS += such_ts
+such_ts_LDADD = $(such_LDADD)
+such_ts_SOURCES = $(such_SOURCES)
+such_ts_CFLAGS = $(such_CFLAGS)
+such_ts_CPPFLAGS = $(such_CPPFLAGS) -DDOGECOIN_TS=1
+such_ts_LDFLAGS = $(such_LDFLAGS)
+
 if WITH_NET
 inst_PROGRAMS += sendtx
 sendtx_LDADD = libdogecoin.la $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(LIBSECP256K1) $(ASM_LIB_FILES)
@@ -443,13 +455,27 @@ sendtx_CFLAGS = $(libdogecoin_la_CFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS
 sendtx_CPPFLAGS = -I$(top_srcdir)/src
 sendtx_LDFLAGS = -static
 
+inst_PROGRAMS += sendtx_ts
+sendtx_ts_LDADD = $(sendtx_LDADD)
+sendtx_ts_SOURCES = $(sendtx_SOURCES)
+sendtx_ts_CFLAGS = $(sendtx_CFLAGS)
+sendtx_ts_CPPFLAGS = $(sendtx_CPPFLAGS) -DDOGECOIN_TS=1
+sendtx_ts_LDFLAGS = $(sendtx_LDFLAGS)
+
 inst_PROGRAMS += spvnode
-spvnode_LDADD = libdogecoin.la $(ASM_LIB_FILES)
+spvnode_LDADD = libdogecoin.la $(EVENT_PTHREADS_LIBS) $(EVENT_LIBS) $(ASM_LIB_FILES)
 spvnode_SOURCES = \
     src/cli/spvnode.c
-spvnode_CFLAGS = $(libdogecoin_la_CFLAGS)
+spvnode_CFLAGS = $(libdogecoin_la_CFLAGS) $(EVENT_CFLAGS) $(EVENT_PTHREADS_CFLAGS)
 spvnode_CPPFLAGS = -I$(top_srcdir)/src
 spvnode_LDFLAGS = -static
+
+inst_PROGRAMS += spvnode_ts
+spvnode_ts_LDADD = $(spvnode_LDADD)
+spvnode_ts_SOURCES = $(spvnode_SOURCES)
+spvnode_ts_CFLAGS = $(spvnode_CFLAGS)
+spvnode_ts_CPPFLAGS = $(spvnode_CPPFLAGS) -DDOGECOIN_TS=1
+spvnode_ts_LDFLAGS = $(spvnode_LDFLAGS)
 endif
 endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -340,9 +340,16 @@ if test "x$with_net" = xyes; then
   AC_CHECK_LIB([event],[main],EVENT_LIBS=-levent,AC_MSG_ERROR(libevent missing))
   AC_CHECK_LIB([event_core],[main],EVENT_CORE_LIBS=-levent_core,AC_MSG_ERROR(libevent_core missing),[-levent_core])
   AC_CHECK_LIB([event_extra],[main],EVENT_EXTRA_LIBS=-levent_extra,AC_MSG_ERROR(libevent_extra missing))
-  if test "$host" = "mingw"; then
-    AC_CHECK_LIB([event_pthreads],[main],EVENT_PTHREADS_LIBS=-levent_pthreads,AC_MSG_ERROR(libevent_pthreads missing))
-  fi
+  AC_CHECK_LIB([event_pthreads],[main],EVENT_PTHREADS_LIBS=-levent_pthreads,[
+    case "$host_os" in
+      mingw*|msys*|cygwin*)
+        EVENT_PTHREADS_LIBS=
+        ;;
+      *)
+        AC_MSG_ERROR(libevent_pthreads missing)
+        ;;
+    esac
+  ])
   LIBS="$LIBS $EVENT_LIBS $EVENT_CORE_LIBS $EVENT_EXTRA_LIBS $EVENT_PTHREADS_LIBS"
 fi
 

--- a/contrib/examples/example.c
+++ b/contrib/examples/example.c
@@ -342,8 +342,10 @@ int main() {
 		return -1;
 	}
 
-	printf("Transaction hex: %s\n", get_raw_transaction(idx));
-	printf("Transaction hex length: %ld\n", strlen(get_raw_transaction(idx)));
+	char txhex_buf[TXHEXMAXLEN + 1] = {0};
+	get_raw_transaction_ex(idx, txhex_buf, sizeof(txhex_buf));
+	printf("Transaction hex: %s\n", txhex_buf);
+	printf("Transaction hex length: %ld\n", strlen(txhex_buf));
 	printf("Transaction unsigned hex: %s\n", get_raw_transaction(idx2));
 	printf("Transaction unsigned hex length: %ld\n", strlen(get_raw_transaction(idx2)));
 	printf("str: %s\n", str);
@@ -351,9 +353,9 @@ int main() {
 	printf("my script pubkey length: %ld\n", strlen(myscriptpubkey));
 	printf("privkeywif: %s\n", wifstr);
 
-	// sign transaction
-	if (sign_transaction(idx, myscriptpubkey, wifstr)) {
-		printf("\nAll transaction inputs signed successfully. \nFinal transaction hex: %s\n.", get_raw_transaction(idx));
+	// sign transaction using buffered _ex API
+	if (sign_transaction_ex(idx, myscriptpubkey, wifstr, txhex_buf, sizeof(txhex_buf))) {
+		printf("\nAll transaction inputs signed successfully. \nFinal transaction hex: %s\n.", txhex_buf);
 	}
 	else {
 		printf("Error occurred.\n");

--- a/doc/thread_safety.md
+++ b/doc/thread_safety.md
@@ -1,0 +1,278 @@
+# Thread safety model (libdogecoin)
+
+This document describes which libdogecoin APIs are safe to call from multiple
+threads and the concurrency mechanisms the library provides.
+
+> Thread-safe (`_ts`) library APIs provide per-object or per-context mutex
+> protection. The CLI tools ship in two flavours: the legacy single-threaded
+> binaries (`such`, `sendtx`, `spvnode`) and thread-safe variants
+> (`such_ts`, `sendtx_ts`, `spvnode_ts`) compiled with `-DDOGECOIN_TS=1` that
+> route through the `_ts` APIs.
+
+## Overview of the concurrency model
+
+libdogecoin uses two complementary strategies:
+
+1. **Thread-local state for legacy globals.** Several internal registries that
+   were historically process-global are declared `DOGECOIN_THREAD_LOCAL`, so
+   each thread gets its own independent copy and no locking is required:
+   * the hash/map registries (`hashes`, `maps` in `include/dogecoin/map.h`),
+   * the wallet UTXO list (`utxos` in `include/dogecoin/wallet.h`),
+   * the default transaction context (`src/transaction.c`),
+   * the hex conversion scratch buffers (`src/utils.c`),
+   * the RNG function pointers / mapper (`src/random.c`).
+
+   `DOGECOIN_THREAD_LOCAL` expands to `_Thread_local`, `__thread`, or
+   `__declspec(thread)` depending on the toolchain (`include/dogecoin/dogecoin.h`).
+
+2. **Explicit contexts and per-object mutexes for shared, mutable state.** When
+   an object genuinely needs to be shared between threads, the library provides
+   `_ts` constructors/operations that embed and take a `dogecoin_mutex_t`. These
+   are the context objects (`dogecoin_context`, `dogecoin_eckey_context`,
+   `dogecoin_transaction_context`) and the per-object `_ts` wrappers for the
+   transaction builder and the wallet.
+
+The SPV client itself runs its message loop on the single libevent IO thread;
+there is no internal worker pool. Apps that want concurrency drive their own
+threads and share only the `_ts`-protected objects described below.
+
+## Mutex helpers
+
+`include/dogecoin/dogecoin.h` provides a tiny portable mutex wrapper used by all
+`_ts` objects:
+
+* `dogecoin_mutex_init` / `dogecoin_mutex_lock` / `dogecoin_mutex_unlock` /
+  `dogecoin_mutex_destroy` — inline wrappers over `pthread_mutex_*` (POSIX) or
+  `CRITICAL_SECTION` (Windows). Each is a no-op when threads are unavailable or
+  the mutex was never initialized, so the same code compiles cleanly with or
+  without threading support.
+
+## Context API
+
+The context object is reference counted; the refcount is guarded by a
+process-wide mutex (`src/context.c`):
+
+* `dogecoin_context_new` / `dogecoin_ctx_new` — create a context (the `ctx`
+  spelling is a short alias of the `context` spelling).
+* `dogecoin_ctx_new_ts` — like `dogecoin_ctx_new` but tags the context as
+  thread-safe so dependent code can branch on `dogecoin_ctx_is_thread_safe(ctx)`.
+* `dogecoin_ctx_acquire` — increment the refcount before handing the context to
+  another thread.
+* `dogecoin_ctx_release` — decrement the refcount; the final release frees it.
+* `dogecoin_ctx_is_thread_safe` — query the thread-safe flag.
+
+## API thread-safety summary
+
+### Safe to call from multiple threads
+
+* The context refcount APIs above (`dogecoin_ctx_new`/`_ts`/`acquire`/`release`/
+  `is_thread_safe`) — the refcount is mutex-guarded.
+* `dogecoin_ecc_start` / `dogecoin_ecc_stop` — process-wide singletons, refcounted.
+* Read access to chain parameters (`&dogecoin_chainparams_main`, etc.) — they
+  are immutable after process start.
+* Anything backed by `DOGECOIN_THREAD_LOCAL` state (hex helpers, per-thread
+  hash/map registries, per-thread UTXO list) — each thread is fully isolated.
+
+### Safe to share across threads via `_ts` variants
+
+* eckey context (`dogecoin_eckey_context_new`/`_free`, `new_eckey_ts`,
+  `new_eckey_from_privkey_ts`, `add_eckey_ts`, `find_eckey_ts`,
+  `remove_eckey_ts`, `start_key_ts`).
+* transaction context (`dogecoin_transaction_context_new`/`_free`,
+  `new_transaction_ts`, `add_transaction_ts`, `find_transaction_ts`,
+  `remove_transaction_ts`, `remove_all_ts`, `get_transaction_count_ts`,
+  `start_transaction_ts`).
+* transaction builder (`dogecoin_tx_new_ts`, `dogecoin_tx_add_input_ts`,
+  `dogecoin_tx_add_output_ts`, `dogecoin_tx_sign_ts`,
+  `dogecoin_tx_finalize_ts`, `dogecoin_tx_free_ts`).
+* wallet (`dogecoin_wallet_new_ts`, `dogecoin_wallet_load_ts`,
+  `dogecoin_wallet_add_hd_account_ts`, `dogecoin_wallet_get_address_ts`,
+  `dogecoin_wallet_save_ts`, `dogecoin_wallet_free_ts`).
+
+### Not thread-safe (must be single-threaded)
+
+* `dogecoin_hdnode_*` mutation APIs.
+* The non-`_ts` `working_transaction` / `eckey` slab APIs — use the `_ts`
+  variants with an explicit context if you need sharing.
+* SPV client objects and their per-node counters — driven on the libevent IO
+  thread only.
+
+Callers that need to mix non-TS APIs with concurrent work should keep each
+non-TS object on a single owning thread.
+
+## Code examples
+
+### Single-threaded (legacy) usage
+
+```c
+#include <dogecoin/libdogecoin.h>
+
+dogecoin_context* ctx = dogecoin_context_new(false, false);
+if (!ctx) { /* handle error */ }
+char wif[PRIVKEYWIFLEN]  = {0};
+char addr[P2PKHLEN]      = {0};
+size_t wif_n = sizeof(wif), addr_n = sizeof(addr);
+dogecoin_generate_keypair_ex(ctx, wif, &wif_n, addr, &addr_n);
+dogecoin_context_release(ctx);
+```
+
+### Multi-threaded (`_ts`) usage
+
+```c
+#include <dogecoin/libdogecoin.h>
+
+/* One context shared between threads. The refcount is mutex-guarded. */
+dogecoin_ctx* ctx = dogecoin_ctx_new_ts(false, false);
+
+/* Each thread acquires before use and releases when it is done. */
+dogecoin_ctx_acquire(ctx);
+/* ... do work, e.g. call dogecoin_generate_keypair_ex(ctx, ...) ... */
+dogecoin_ctx_release(ctx);
+
+/* Final release frees the context. */
+dogecoin_ctx_release(ctx);
+```
+
+### Recommended usage patterns
+
+* Use `dogecoin_ctx_new_ts()` for concurrent apps and keep object ownership
+  explicit.
+* Prefer **one mutable wallet/transaction object per worker thread** whenever
+  possible to minimize lock contention.
+* If sharing a wallet object across threads, use only the `_ts` wallet
+  functions (`dogecoin_wallet_*_ts`) and avoid mixing direct non-`_ts` wallet
+  mutation in parallel.
+* For signing, `dogecoin_tx_sign_ts()` acquires locks in a fixed order
+  (`tx->lock` then `wallet->lock`) to avoid inversion.
+
+### Wallet `_ts` usage example
+
+```c
+dogecoin_ctx* ctx = dogecoin_ctx_new_ts(false, false);
+dogecoin_wallet* wallet = dogecoin_wallet_load_ts(ctx, "main_wallet.db");
+char addr[P2PKHLEN] = {0};
+
+dogecoin_wallet_add_hd_account_ts(wallet, 0);
+dogecoin_wallet_get_address_ts(wallet, addr, sizeof(addr), 0, 0, false);
+dogecoin_wallet_save_ts(wallet);
+dogecoin_wallet_free_ts(wallet);
+dogecoin_ctx_release(ctx);
+```
+
+### Transaction `_ts` usage example
+
+```c
+dogecoin_tx* tx = dogecoin_tx_new_ts();
+dogecoin_tx_in* in = dogecoin_tx_in_new();
+dogecoin_tx_out* out = dogecoin_tx_out_new();
+/* initialize prevout/script/value fields before add_*_ts calls */
+dogecoin_tx_add_input_ts(tx, in);
+dogecoin_tx_add_output_ts(tx, out);
+dogecoin_tx_in_free(in);
+dogecoin_tx_out_free(out);
+dogecoin_tx_sign_ts(tx, wallet, NULL);
+dogecoin_tx_finalize_ts(tx);
+dogecoin_tx_free_ts(tx);
+```
+
+## Thread-safe CLI variants
+
+The build produces a thread-safe variant of each CLI alongside the legacy
+binary:
+
+| legacy        | thread-safe      |
+|---------------|------------------|
+| `such`        | `such_ts`        |
+| `sendtx`      | `sendtx_ts`      |
+| `spvnode`     | `spvnode_ts`     |
+
+The `_ts` binaries are the same sources compiled with `-DDOGECOIN_TS=1`. The CLIs
+route thread-safe operations through `include/dogecoin/threadsafe.h`
+(`#include <dogecoin/threadsafe.h>`). Operations whose `_ts` variant shares the
+exact signature of the plain API (the direct `dogecoin_tx` create/free calls)
+are routed with a compile-time rename, so the CLI sources keep calling the
+canonical `dogecoin_tx_new()`/`dogecoin_tx_free()` names. Operations whose `_ts`
+variant takes an extra context argument or has a distinct lifecycle are routed
+through explicit, greppable `cli_*` wrappers that inject the context for the
+caller. Each rename or wrapper resolves to the matching `_ts` library API under
+`-DDOGECOIN_TS` and the plain API otherwise; the two builds are otherwise
+identical.
+
+At startup the `_ts` tools create a thread-safe context and announce it, e.g.:
+
+```
+such: thread-safe mode enabled
+```
+
+The legacy binaries are unaffected and print nothing extra.
+
+### What the `_ts` CLI builds exercise
+
+In the `_ts` build, every object the CLI creates is the thread-safe
+(mutex-bearing) variant operating under a thread-safe context, and every CLI
+code path that builds, mutates or serializes a transaction routes through the
+thread-safe library APIs rather than holding ad-hoc locks around the legacy
+ones.
+
+The transaction-building wrappers (`cli_add_utxo`, `cli_add_output`,
+`cli_finalize_transaction`, `cli_save_raw_transaction`, `cli_get_raw_transaction`,
+`cli_clear_transaction`) call the `_ts` variants of the higher-level index
+functions (`add_utxo_ts`, `add_output_ts`, `finalize_transaction_ts`,
+`save_raw_transaction_ts`, `get_raw_transaction_ts`, `clear_transaction_ts`).
+Those variants in turn drive the per-object transaction primitives
+(`dogecoin_tx_add_input_ts`, `dogecoin_tx_add_output_ts`,
+`dogecoin_tx_finalize_ts`) and serialize/copy under the working transaction's
+`dogecoin_tx.lock`. The context lifecycle, registry, eckey and wallet wrappers,
+together with the `dogecoin_tx_new()`/`dogecoin_tx_free()` compile-time renames,
+route through the matching `_ts` context, registry and per-object APIs in the
+same way. The non-`_ts` higher-level index functions are
+thin wrappers that delegate to the same `_ts` implementations against the
+per-thread default context, so the legacy and thread-safe builds share a single
+code path and produce byte-identical transactions.
+
+Because the wrappers route through the `_ts` APIs end to end, there is no
+explicit coverage matrix carving out primitives that the CLI does not exercise:
+the thread-safe build drives the thread-safe transaction primitives directly.
+The remaining wallet/eckey `_ts` surface that has no dedicated CLI command is
+additionally validated by the unit-test suite (`test/transaction_tests.c`,
+`test/wallet_tests.c`, `test/eckey_tests.c`).
+
+Notes:
+
+* The registry and eckey contexts hold only a hashmap and rely on per-thread
+  isolation (no internal mutex); the real locks live on `dogecoin_tx.lock`,
+  `dogecoin_wallet.lock` and the `dogecoin_ctx` refcount mutex.
+* The index-based transaction API binds to the per-thread *default* transaction
+  context, so the `cli_*` registry/index wrappers target that same default
+  context to keep index lookups consistent.
+* `_ts` working transactions are mutex-bearing because `new_transaction_ts`
+  constructs them with `dogecoin_tx_new_ts()`; the legacy `new_transaction`
+  path remains lock-free.
+
+## Verifying with sanitizers
+
+```sh
+# ThreadSanitizer build (autotools)
+CFLAGS="-fsanitize=thread -O1 -g" \
+LDFLAGS="-fsanitize=thread" \
+./configure --with-net --with-tools --enable-test-passwd
+make -j$(nproc)
+LIBDOGECOIN_TEST_PASSWD=testpass ./tests
+```
+
+```sh
+# Valgrind (helgrind) for lock-order auditing
+valgrind --tool=helgrind ./tests
+```
+
+## Roadmap for `_ts` API surface
+
+The following modules still require single-thread ownership; `_ts` variants
+remain tracked here for a future pass:
+
+* HD derivation (`dogecoin_hdnode_*`) — derivation is functional; the
+  `_ts` variants should protect cached child key tables when caches exist.
+* SPV client — the runloop is single-threaded on the libevent IO thread; a
+  future pass could parallelize header/block validation behind an opt-in `_ts`
+  entry point.
+

--- a/doc/tools.md
+++ b/doc/tools.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-If you are looking to just explore the functionality of Libdogecoin without building a complicated project yourself, look no further than the CLI tools provided in this repo. The first tool, `such`, is an interactive CLI application that allows you to perform all Essential address and transaction operations with prompts to guide you through the process. The second tool, `sendtx`, handles the process of broadcasting a transaction built using Libdogecoin to eventually push it onto the blockchain. The third tool, `spvnode`, run a Simple Payment Verification (SPV) node for the Dogecoin blockchain. It enables users to interact with the Dogecoin network, verify transactions and stay in sync with the blockchain.
+If you are looking to just explore the functionality of Libdogecoin without building a complicated project yourself, look no further than the CLI tools provided in this repo. The first tool, `such`, is an interactive CLI application that allows you to perform all Essential address and transaction operations with prompts to guide you through the process. The second tool, `sendtx`, handles the process of broadcasting a transaction built using Libdogecoin to eventually push it onto the blockchain. The third tool, `spvnode`, run a Simple Payment Verification (SPV) node for the Dogecoin blockchain. It enables users to interact with the Dogecoin network, verify transactions and stay in sync with the blockchain. Each tool is also built as a thread-safe variant (`such_ts`, `sendtx_ts`, `spvnode_ts`) that routes through the thread-safe library APIs.
 
 This document goes over the usage of these tools along with examples of how to use them.
 
@@ -420,7 +420,7 @@ To choose a checkpoint start manually (all available checkpoints shown), apply t
 | `-r`, `--regtest` | Regtest Mode | No | Activate regtest network: `./spvnode -r scan` |
 | `-i`, `--ips` | Initial Peers | Yes | Specify initial peers: `./spvnode -i 127.0.0.1:22556 scan` |
 | `-d`, `--debug` | Debug Mode | No | Enable debug output: `./spvnode -d scan` |
-| `-m`, `--maxnodes` | Max Peers | No | Set max peers: `./spvnode -m 8 scan` |
+| `-m`, `--maxnodes` | Max Peers | Yes | Set max peers: `./spvnode -m 8 scan` |
 | `-a`, `--address` | Address | Yes | Use address: `./spvnode -a "your address here" scan` |
 | `-n`, `--mnemonic` | Mnemonic Seed | Yes | Use BIP39 mnemonic: `./spvnode -n "your mnemonic here" scan` |
 | `-s`, `--pass_phrase` | Passphrase | No | Passphrase for BIP39 seed: `./spvnode -s scan` |
@@ -439,6 +439,12 @@ To choose a checkpoint start manually (all available checkpoints shown), apply t
 | `-x`, `--smpv` | Enable SMPV | No | Enabled SMPV: `./spvnode -x scan` |
 | `-g`, `--filtered_blocks` | Filtered Blocks | No | Enable BIP37 filtered blocks: `./spvnode -g scan` |
 | `-q`, `--select_checkpoint` | Select Checkpoint | No | Prompt for checkpoint start (defaults to latest when used with `-l`): `./spvnode -q scan` |
+
+`spvnode` uses a libevent runloop for asynchronous network I/O and can request headers from multiple peers in parallel. The message loop itself runs on the single libevent IO thread.
+
+A thread-safe build of each CLI is also produced — `such_ts`, `sendtx_ts`, and `spvnode_ts` — compiled with `-DDOGECOIN_TS=1` so they route through the thread-safe (`_ts`) library APIs and announce thread-safe mode at startup (for example, `such: thread-safe mode enabled`). The legacy binaries (`such`, `sendtx`, `spvnode`) behave exactly as before. See [thread_safety.md](thread_safety.md) for the full `_ts` API surface.
+
+Note: `_ts` APIs are used where explicit context or per-object ownership is required for thread safety. If a function can be made thread-safe without changing parameters (for example via thread-local state), the original API name is preferred.
 
 ### Commands
 

--- a/doc/transaction.md
+++ b/doc/transaction.md
@@ -31,6 +31,12 @@
 
 The high level 'essential' API provided by libdogecoin for working with simple transactions revolve around a structure defined as a `working_transaction` which is comprised of an index as an integer meant for retrieval, a dogecoin_tx 'transaction' structure as seen above, and finally a UT_hash_handle which stores our working_transaction struct in a hash table (using Troy D. Hanson's uthash library: see ./include/dogecoin/uthash.h and visit https://troydhanson.github.io/uthash/ for more information) which allow us to generate multiple transactions per "session". This `working_transaction` structure is defined as such:
 
+Buffered `_ex` transaction APIs are retained as the primary API surface (for example `sign_raw_transaction_ex`). Where thread safety can be provided without changing parameters, the original API is preferred over adding extra aliases.
+
+Thread-safety policy: `_ts` APIs are used when explicit context ownership is required. For APIs that can be made thread-safe without signature changes, the original API names are used directly.
+
+The higher-level index functions also provide `_ts` variants that take an explicit `dogecoin_transaction_context*` and route through the per-object transaction primitives (`dogecoin_tx_add_input_ts`, `dogecoin_tx_add_output_ts`, `dogecoin_tx_finalize_ts`): `add_utxo_ts`, `add_output_ts`, `finalize_transaction_ts`, `save_raw_transaction_ts`, `get_raw_transaction_ts`, and `clear_transaction_ts`. The non-`_ts` functions are thin wrappers that delegate to these against the per-thread default context, so both paths share a single implementation. The thread-safe CLI builds (`such_ts`, `sendtx_ts`, `spvnode_ts`) call the `_ts` variants. See [thread_safety.md](thread_safety.md).
+
 ```C
 typedef struct working_transaction {
     int index;

--- a/include/dogecoin/dogecoin.h
+++ b/include/dogecoin/dogecoin.h
@@ -34,11 +34,62 @@
 #include <stdlib.h>
 #include <string.h>
 
+/* Pull in libdogecoin-config.h early so platform gates below (e.g. USE_OPTEE)
+ * are visible before we decide whether to enable a pthread-backed mutex. */
 #if defined(HAVE_CONFIG_H) && !defined(USE_LIB)
 #include <config/libdogecoin-config.h>
 #endif
 
+#ifdef _WIN32
+/* Require Windows 8+ so both winnls.h's NormalizationKD/NormalizeString and
+ * winsock2.h's htonll/ntohll prototypes are visible to all consumers of this
+ * header. (NormalizationKD needs 0x0600, htonll needs 0x0602.) */
+#ifndef _WIN32_WINNT
+#define _WIN32_WINNT 0x0602
+#endif
+#ifndef WINVER
+#define WINVER 0x0602
+#endif
+/* Avoid pulling in legacy <winsock.h> from <windows.h>, which would conflict
+ * with <winsock2.h> included by libdogecoin's net code on MSVC. */
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#define DOGECOIN_HAVE_THREADS 1
+/* Only enable pthread-backed mutexes on hosted POSIX-like targets where we
+ * know <pthread.h> exists AND the pthread runtime will be linked.  Bare-metal
+ * / freestanding targets such as OP-TEE Trusted Applications (libutee) ship a
+ * <pthread.h> via the cross toolchain headers but cannot resolve
+ * pthread_mutex_* at link time, so they fall through to the no-op stubs. */
+#elif !defined(USE_OPTEE) && \
+      (defined(__GLIBC__) || defined(__BIONIC__) || defined(__APPLE__) || \
+       defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || \
+       defined(__DragonFly__) || defined(__CYGWIN__) || defined(__MINGW32__) || \
+       defined(__MINGW64__) || defined(__sun) || defined(__HAIKU__))
+#include <pthread.h>
+#define DOGECOIN_HAVE_THREADS 1
+#endif
+
 typedef uint8_t dogecoin_bool; //!serialize, c/c++ save bool
+
+struct dogecoin_context_;
+/* Short-form context alias used by the `_ts` API surface. */
+typedef struct dogecoin_context_ dogecoin_ctx;
+
+typedef struct dogecoin_mutex_ {
+#ifdef _WIN32
+    CRITICAL_SECTION handle;
+#elif defined(DOGECOIN_HAVE_THREADS)
+    pthread_mutex_t handle;
+#else
+    /* Freestanding/baremetal targets (e.g. OP-TEE TAs) without a threading
+     * runtime: keep the struct compilable; the inline helpers below become
+     * no-ops, and TS APIs must not be invoked in such builds. */
+    int handle;
+#endif
+    dogecoin_bool initialized;
+} dogecoin_mutex_t;
 
 #ifndef __cplusplus
 #ifndef true
@@ -70,6 +121,17 @@ typedef uint8_t dogecoin_bool; //!serialize, c/c++ save bool
 #else
 #define LIBDOGECOIN_API
 #endif
+#endif
+
+#if defined(_MSC_VER)
+#define DOGECOIN_THREAD_LOCAL __declspec(thread)
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L
+#define DOGECOIN_THREAD_LOCAL _Thread_local
+#elif defined(__GNUC__) || defined(__clang__)
+#define DOGECOIN_THREAD_LOCAL __thread
+#else
+/* Fallback for compilers without TLS support. */
+#define DOGECOIN_THREAD_LOCAL
 #endif
 
 #if defined(_MSC_VER)
@@ -156,7 +218,79 @@ typedef uint8_t uint256_t[32];
 typedef uint8_t uint160_t[20];
 typedef uint8_t SEED[MAX_SEED_SIZE];
 
+/* Generic pointer vector container shared by the public and internal APIs */
+typedef struct vector_t {
+    void** data;  /* array of pointers */
+    size_t len;   /* array element count */
+    size_t alloc; /* allocated array elements */
+
+    void (*elem_free_f)(void*);
+} vector_t;
+
+#define vector_idx(vec, idx) vec->data[idx]
+
 static const int WIDTH = 0x0000100/32;
+
+LIBDOGECOIN_API dogecoin_ctx* dogecoin_ctx_new(dogecoin_bool testnet, dogecoin_bool enable_net);
+LIBDOGECOIN_API dogecoin_ctx* dogecoin_ctx_new_ts(dogecoin_bool testnet, dogecoin_bool enable_net);
+LIBDOGECOIN_API void dogecoin_ctx_acquire(dogecoin_ctx* ctx);
+LIBDOGECOIN_API void dogecoin_ctx_release(dogecoin_ctx* ctx);
+LIBDOGECOIN_API int dogecoin_ctx_is_thread_safe(const dogecoin_ctx* ctx);
+
+static inline dogecoin_bool dogecoin_mutex_init(dogecoin_mutex_t* mutex)
+{
+    if (!mutex) return false;
+#ifdef _WIN32
+    InitializeCriticalSection(&mutex->handle);
+    mutex->initialized = true;
+    return true;
+#elif defined(DOGECOIN_HAVE_THREADS)
+    if (pthread_mutex_init(&mutex->handle, NULL) != 0) {
+        mutex->initialized = false;
+        return false;
+    }
+    mutex->initialized = true;
+    return true;
+#else
+    (void)mutex;
+    return false;
+#endif
+}
+
+static inline void dogecoin_mutex_lock(dogecoin_mutex_t* mutex)
+{
+    if (!mutex || !mutex->initialized) return;
+#ifdef _WIN32
+    EnterCriticalSection(&mutex->handle);
+#elif defined(DOGECOIN_HAVE_THREADS)
+    pthread_mutex_lock(&mutex->handle);
+#else
+    (void)mutex;
+#endif
+}
+
+static inline void dogecoin_mutex_unlock(dogecoin_mutex_t* mutex)
+{
+    if (!mutex || !mutex->initialized) return;
+#ifdef _WIN32
+    LeaveCriticalSection(&mutex->handle);
+#elif defined(DOGECOIN_HAVE_THREADS)
+    pthread_mutex_unlock(&mutex->handle);
+#else
+    (void)mutex;
+#endif
+}
+
+static inline void dogecoin_mutex_destroy(dogecoin_mutex_t* mutex)
+{
+    if (!mutex || !mutex->initialized) return;
+#ifdef _WIN32
+    DeleteCriticalSection(&mutex->handle);
+#elif defined(DOGECOIN_HAVE_THREADS)
+    pthread_mutex_destroy(&mutex->handle);
+#endif
+    mutex->initialized = false;
+}
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/eckey.h
+++ b/include/dogecoin/eckey.h
@@ -45,29 +45,37 @@ typedef struct eckey {
     UT_hash_handle hh;
 } eckey;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-static eckey *keys = NULL;
-#pragma GCC diagnostic pop
+typedef struct dogecoin_eckey_context {
+    eckey* keys;
+} dogecoin_eckey_context;
 
 // instantiates a new eckey
 LIBDOGECOIN_API eckey* new_eckey(dogecoin_bool is_testnet);
+LIBDOGECOIN_API eckey* new_eckey_ts(dogecoin_eckey_context* ctx, dogecoin_bool is_testnet);
 
 LIBDOGECOIN_API eckey* new_eckey_from_privkey(char* key);
+LIBDOGECOIN_API eckey* new_eckey_from_privkey_ts(dogecoin_eckey_context* ctx, char* key);
 
 // adds eckey structure to hash table
 LIBDOGECOIN_API void add_eckey(eckey *key);
+LIBDOGECOIN_API void add_eckey_ts(dogecoin_eckey_context* ctx, eckey *key);
 
 // find eckey from the hash table
 LIBDOGECOIN_API eckey* find_eckey(int idx);
+LIBDOGECOIN_API eckey* find_eckey_ts(dogecoin_eckey_context* ctx, int idx);
 
 // remove eckey from the hash table
 LIBDOGECOIN_API void remove_eckey(eckey *key);
+LIBDOGECOIN_API void remove_eckey_ts(dogecoin_eckey_context* ctx, eckey *key);
 
 LIBDOGECOIN_API void dogecoin_key_free(eckey* eckey);
 
 // instantiates and adds key to the hash table
 LIBDOGECOIN_API int start_key(dogecoin_bool is_testnet);
+LIBDOGECOIN_API int start_key_ts(dogecoin_eckey_context* ctx, dogecoin_bool is_testnet);
+
+LIBDOGECOIN_API dogecoin_eckey_context* dogecoin_eckey_context_new(void);
+LIBDOGECOIN_API void dogecoin_eckey_context_free(dogecoin_eckey_context* ctx);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/libdogecoin.h
+++ b/include/dogecoin/libdogecoin.h
@@ -66,6 +66,22 @@ typedef struct dogecoin_checkpoint_ {
     uint32_t target;
 } dogecoin_checkpoint;
 
+struct dogecoin_transaction_context;
+struct dogecoin_eckey_context;
+typedef struct dogecoin_context_ {
+    const dogecoin_chainparams* chain_params;
+    struct dogecoin_transaction_context* tx_ctx;
+    struct dogecoin_eckey_context* key_ctx;
+    void* ecc_ctx;
+    void* rng_state;
+    void* refcount_lock;
+    int enable_net;
+    int error_code;
+    uint32_t refcount;
+    int thread_safe; /* nonzero when constructed via dogecoin_ctx_new_ts() (alias in dogecoin.h) */
+    char last_error[256];
+} dogecoin_context;
+
 /* forward declarations for opaque types referenced by the PQC and ZK APIs */
 typedef struct cstring cstring;
 
@@ -99,6 +115,32 @@ extern const dogecoin_checkpoint dogecoin_testnet_checkpoint_array[24];
 
 const dogecoin_chainparams* chain_from_b58_prefix(const char* address);
 int chain_from_b58_prefix_bool(char* address);
+
+dogecoin_context* dogecoin_context_new(dogecoin_bool testnet, dogecoin_bool enable_net);
+void dogecoin_context_acquire(dogecoin_context* ctx);
+void dogecoin_context_release(dogecoin_context* ctx);
+const dogecoin_chainparams* dogecoin_context_get_chainparams(const dogecoin_context* ctx);
+struct dogecoin_transaction_context* dogecoin_context_get_transaction_context(dogecoin_context* ctx);
+struct dogecoin_eckey_context* dogecoin_context_get_eckey_context(dogecoin_context* ctx);
+void* dogecoin_context_get_ecc_context(dogecoin_context* ctx);
+void* dogecoin_context_get_rng_state(dogecoin_context* ctx);
+void dogecoin_context_set_error(dogecoin_context* ctx, int code, const char* msg);
+int dogecoin_context_get_error_code(const dogecoin_context* ctx);
+const char* dogecoin_context_get_error(const dogecoin_context* ctx);
+int dogecoin_generate_keypair_ex(dogecoin_context* ctx, char* wif, size_t* wif_size, char* addr, size_t* addr_size);
+
+/* THREAD-SAFE short-form aliases for the dogecoin_context API.
+ * dogecoin_ctx_new() returns a context whose refcount is guarded by a
+ * process-wide mutex; dogecoin_ctx_new_ts() additionally tags the context
+ * as thread-safe so dependent subsystems (wallet / tx / spv helpers) can
+ * select per-object locking when wired through the context. The non-_ts
+ * constructor remains thread-compatible: any single owning thread may use
+ * it, and reference counting is always atomic. */
+dogecoin_ctx* dogecoin_ctx_new(dogecoin_bool testnet, dogecoin_bool enable_net);
+dogecoin_ctx* dogecoin_ctx_new_ts(dogecoin_bool testnet, dogecoin_bool enable_net);
+void dogecoin_ctx_acquire(dogecoin_ctx* ctx);
+void dogecoin_ctx_release(dogecoin_ctx* ctx);
+int dogecoin_ctx_is_thread_safe(const dogecoin_ctx* ctx);
 
 /* basic address functions: return 1 if succesful
    ----------------------------------------------
@@ -330,7 +372,7 @@ dogecoin_bool deriveBIP44ExtendedPublicKey(
 uint8_t* utils_hex_to_uint8(const char* str);
 char* utils_uint8_to_hex(const uint8_t* bin, size_t l);
 void utils_hex_to_bin(const char* str, unsigned char* out, size_t inLen, size_t* outLen);
-void utils_bin_to_hex(unsigned char* bin_in, size_t inlen, char* hex_out);
+void utils_bin_to_hex(const unsigned char* bin_in, size_t inlen, char* hex_out);
 char* getpass(const char *prompt);
 
 /* Advanced API functions for mnemonic seedphrase generation
@@ -622,11 +664,6 @@ typedef struct eckey {
     UT_hash_handle hh;
 } eckey;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-static eckey *keys = NULL;
-#pragma GCC diagnostic pop
-
 // instantiates a new eckey
 eckey* new_eckey(dogecoin_bool is_testnet);
 // instantiates a new eckey from a WIF-encoded private key
@@ -656,16 +693,6 @@ int verify_message(char* sig, char* msg, char* address);
 /* Vector API
 --------------------------------------------------------------------------
 */
-
-typedef struct vector_t {
-    void** data;  /* array of pointers */
-    size_t len;   /* array element count */
-    size_t alloc; /* allocated array elements */
-
-    void (*elem_free_f)(void*);
-} vector_t;
-
-#define vector_idx(vec, idx) vec->data[idx]
 
 /* create a new vector with initial reserve and optional element destructor */
 vector_t* vector_new(size_t res, void (*free_f)(void*));

--- a/include/dogecoin/map.h
+++ b/include/dogecoin/map.h
@@ -75,7 +75,7 @@ typedef struct hash {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
-static hash *hashes = NULL;
+static DOGECOIN_THREAD_LOCAL hash *hashes = NULL;
 #pragma GCC diagnostic pop
 
 // instantiates a new hash
@@ -99,7 +99,7 @@ typedef struct map {
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
-static map *maps = NULL;
+static DOGECOIN_THREAD_LOCAL map *maps = NULL;
 #pragma GCC diagnostic pop
 
 // instantiates a new map

--- a/include/dogecoin/mem.h
+++ b/include/dogecoin/mem.h
@@ -47,8 +47,7 @@ typedef struct dogecoin_mem_mapper {
     void (*dogecoin_free)(void* ptr);
 } dogecoin_mem_mapper;
 
-// sets a custom memory mapper
-// this function is _not_ thread safe and must be called before anything else
+// sets a custom memory mapper for the current thread
 LIBDOGECOIN_API void dogecoin_mem_set_mapper(const dogecoin_mem_mapper mapper);
 LIBDOGECOIN_API void dogecoin_mem_set_mapper_default();
 

--- a/include/dogecoin/random.h
+++ b/include/dogecoin/random.h
@@ -67,8 +67,7 @@ typedef struct dogecoin_rnd_mapper_ {
     dogecoin_bool (*dogecoin_random_bytes)(uint8_t* buf, uint32_t len, const uint8_t update_seed);
 } dogecoin_rnd_mapper;
 
-// sets a custom random callback mapper
-// this function is NOT thread safe and should be called before anything else
+// sets a custom random callback mapper for the current thread
 LIBDOGECOIN_API void dogecoin_rnd_set_mapper(const dogecoin_rnd_mapper mapper);
 LIBDOGECOIN_API void dogecoin_rnd_set_mapper_default();
 

--- a/include/dogecoin/threadsafe.h
+++ b/include/dogecoin/threadsafe.h
@@ -1,0 +1,394 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2024-2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+/* Thread-safe routing helpers shared by the libdogecoin CLI tools. The CLI
+ * sources are compiled twice: the plain binaries (such, sendtx, spvnode) call
+ * the plain API, and the -DDOGECOIN_TS binaries (such_ts, sendtx_ts,
+ * spvnode_ts) route through the matching _ts library API. See
+ * doc/thread_safety.md. */
+
+#ifndef __LIBDOGECOIN_THREADSAFE_H__
+#define __LIBDOGECOIN_THREADSAFE_H__
+
+#include <stdio.h>
+
+#include <dogecoin/dogecoin.h>
+#include <dogecoin/chainparams.h>
+#include <dogecoin/eckey.h>
+#include <dogecoin/transaction.h>
+#include <dogecoin/tx.h>
+#include <dogecoin/wallet.h>
+
+#ifdef DOGECOIN_TS
+#define DOGECOIN_CLI_TS_LABEL "thread-safe"
+#else
+#define DOGECOIN_CLI_TS_LABEL "single-threaded"
+#endif
+
+/* Thread-safe context lifecycle */
+
+/**
+ * @brief Start the CLI thread-safe context for a tool.
+ *
+ * In the `_ts` build this creates a thread-safe libdogecoin context (a
+ * refcount-mutex guarded object), announces the mode and returns the held
+ * context for the tool to thread through `_ts` object constructors. In the
+ * legacy build it is a no-op that returns NULL.
+ *
+ * @param tool The name of the CLI tool, used in the announcement.
+ * @param testnet Whether the context targets testnet.
+ *
+ * @return The held thread-safe context in the `_ts` build, otherwise NULL.
+ */
+static inline dogecoin_ctx* cli_ts_context_start(const char* tool, dogecoin_bool testnet)
+{
+#ifdef DOGECOIN_TS
+    dogecoin_ctx* ctx = dogecoin_ctx_new_ts(testnet, false);
+    printf("%s: thread-safe mode %s\n", tool,
+           dogecoin_ctx_is_thread_safe(ctx) ? "enabled" : "unavailable");
+    return ctx;
+#else
+    (void)tool;
+    (void)testnet;
+    return NULL;
+#endif
+}
+
+/**
+ * @brief Release the CLI thread-safe context created by cli_ts_context_start().
+ *
+ * In the legacy build this is a no-op.
+ *
+ * @param ctx The context to release.
+ *
+ * @return Nothing.
+ */
+static inline void cli_ts_context_finish(dogecoin_ctx* ctx)
+{
+#ifdef DOGECOIN_TS
+    dogecoin_ctx_release(ctx);
+#else
+    (void)ctx;
+#endif
+}
+
+/* Transaction builder: dogecoin_tx_new_ts()/dogecoin_tx_free_ts() share the exact
+ * signature of the plain create/free calls so they are routed with a compile-time
+ * rename. This lets the CLI sources keep calling the canonical dogecoin_tx_new()/
+ * dogecoin_tx_free() names while the _ts build transparently exercises the
+ * mutex-bearing variants. The renames are only in effect under -DDOGECOIN_TS;
+ * the legacy build uses the plain API unchanged. */
+#ifdef DOGECOIN_TS
+#define dogecoin_tx_new dogecoin_tx_new_ts
+#define dogecoin_tx_free dogecoin_tx_free_ts
+#endif
+
+/* Transaction registry: the CLI builds transactions through the index-based
+ * transaction API which operates on the per-thread default transaction context.
+ * The _ts wrappers below therefore target that same default context so registry
+ * lookups stay consistent with the rest of the index-based API. */
+
+/**
+ * @brief Start a new working transaction in the registry.
+ *
+ * @return The index of the new working transaction.
+ */
+static inline int cli_start_transaction(void)
+{
+#ifdef DOGECOIN_TS
+    return start_transaction_ts(dogecoin_transaction_context_default());
+#else
+    return start_transaction();
+#endif
+}
+
+/**
+ * @brief Find a working transaction by index.
+ *
+ * @param idx The index of the working transaction to find.
+ *
+ * @return The working transaction, or NULL if not found.
+ */
+static inline working_transaction* cli_find_transaction(int idx)
+{
+#ifdef DOGECOIN_TS
+    return find_transaction_ts(dogecoin_transaction_context_default(), idx);
+#else
+    return find_transaction(idx);
+#endif
+}
+
+/**
+ * @brief Remove (and free) a working transaction from the registry.
+ *
+ * @param working_tx The working transaction to remove.
+ *
+ * @return Nothing.
+ */
+static inline void cli_remove_transaction(working_transaction* working_tx)
+{
+#ifdef DOGECOIN_TS
+    remove_transaction_ts(dogecoin_transaction_context_default(), working_tx);
+#else
+    remove_transaction(working_tx);
+#endif
+}
+
+/**
+ * @brief Remove (and free) all working transactions from the registry.
+ *
+ * @return Nothing.
+ */
+static inline void cli_remove_all(void)
+{
+#ifdef DOGECOIN_TS
+    remove_all_ts(dogecoin_transaction_context_default());
+#else
+    remove_all();
+#endif
+}
+
+/**
+ * @brief Count the working transactions currently in the registry.
+ *
+ * @return The number of working transactions.
+ */
+static inline int cli_get_transaction_count(void)
+{
+#ifdef DOGECOIN_TS
+    return get_transaction_count_ts(dogecoin_transaction_context_default());
+#else
+    return get_transaction_count();
+#endif
+}
+
+/* Index-based transaction mutation/serialization: the CLI mutates and serializes
+ * working transactions through the index-based API. In the _ts build the working
+ * transaction is mutex-bearing (created via dogecoin_tx_new_ts() inside
+ * new_transaction_ts), and the _ts index variants route every mutation through
+ * the thread-safe transaction primitives and serialize under the per-transaction
+ * mutex. In the legacy build the lock is absent (thread_safe == 0) and the
+ * wrappers reduce to the plain index API. */
+
+/**
+ * @brief Store a raw (hex) transaction into the working transaction at an index.
+ *
+ * @param txindex The index of the working transaction to populate.
+ * @param hexadecimal_transaction The raw transaction encoded as hex.
+ *
+ * @return 1 on success, 0 on failure.
+ */
+static inline int cli_save_raw_transaction(int txindex, const char* hexadecimal_transaction)
+{
+#ifdef DOGECOIN_TS
+    return save_raw_transaction_ts(dogecoin_transaction_context_default(), txindex, hexadecimal_transaction);
+#else
+    return save_raw_transaction(txindex, hexadecimal_transaction);
+#endif
+}
+
+/**
+ * @brief Add a UTXO input to the working transaction at an index.
+ *
+ * @param txindex The index of the working transaction to mutate.
+ * @param hex_utxo_txid The hex txid of the UTXO to spend.
+ * @param vout The output index of the UTXO to spend.
+ *
+ * @return 1 on success, 0 on failure.
+ */
+static inline int cli_add_utxo(int txindex, char* hex_utxo_txid, int vout)
+{
+#ifdef DOGECOIN_TS
+    return add_utxo_ts(dogecoin_transaction_context_default(), txindex, hex_utxo_txid, vout);
+#else
+    return add_utxo(txindex, hex_utxo_txid, vout);
+#endif
+}
+
+/**
+ * @brief Add an output to the working transaction at an index.
+ *
+ * @param txindex The index of the working transaction to mutate.
+ * @param destinationaddress The destination address for the output.
+ * @param amount The output amount.
+ *
+ * @return 1 on success, 0 on failure.
+ */
+static inline int cli_add_output(int txindex, char* destinationaddress, char* amount)
+{
+#ifdef DOGECOIN_TS
+    return add_output_ts(dogecoin_transaction_context_default(), txindex, destinationaddress, amount);
+#else
+    return add_output(txindex, destinationaddress, amount);
+#endif
+}
+
+/**
+ * @brief Finalize the working transaction at an index, applying fee and change.
+ *
+ * @param txindex The index of the working transaction to finalize.
+ * @param destinationaddress The destination address.
+ * @param subtractedfee The fee to subtract.
+ * @param out_dogeamount_for_verification The total amount for verification.
+ * @param changeaddress The change address.
+ *
+ * @return The finalized raw transaction as hex, or NULL on failure.
+ */
+static inline char* cli_finalize_transaction(int txindex, char* destinationaddress, char* subtractedfee,
+                                             char* out_dogeamount_for_verification, char* changeaddress)
+{
+#ifdef DOGECOIN_TS
+    return finalize_transaction_ts(dogecoin_transaction_context_default(), txindex, destinationaddress,
+                                   subtractedfee, out_dogeamount_for_verification, changeaddress);
+#else
+    return finalize_transaction(txindex, destinationaddress, subtractedfee,
+                                out_dogeamount_for_verification, changeaddress);
+#endif
+}
+
+/**
+ * @brief Serialize the working transaction at an index to raw hex.
+ *
+ * @param txindex The index of the working transaction to serialize.
+ *
+ * @return The raw transaction as hex, or NULL on failure.
+ */
+static inline char* cli_get_raw_transaction(int txindex)
+{
+#ifdef DOGECOIN_TS
+    return get_raw_transaction_ts(dogecoin_transaction_context_default(), txindex);
+#else
+    return get_raw_transaction(txindex);
+#endif
+}
+
+/**
+ * @brief Clear (remove and free) the working transaction at an index.
+ *
+ * clear_transaction removes (and frees) the working transaction, so it is
+ * routed through the thread-safe registry rather than holding the per-object
+ * lock it is about to destroy.
+ *
+ * @param txindex The index of the working transaction to clear.
+ *
+ * @return Nothing.
+ */
+static inline void cli_clear_transaction(int txindex)
+{
+#ifdef DOGECOIN_TS
+    clear_transaction_ts(dogecoin_transaction_context_default(), txindex);
+#else
+    clear_transaction(txindex);
+#endif
+}
+
+/* eckey: the key is a standalone object (never added to a registry), so the
+ * _ts build exercises the eckey context lifecycle with a throwaway context. */
+
+/**
+ * @brief Create an eckey object from a private key string.
+ *
+ * In the `_ts` build the key is built through a throwaway eckey context to
+ * exercise the thread-safe eckey context lifecycle.
+ *
+ * @param private_key The private key string.
+ *
+ * @return The new eckey object, or NULL on failure.
+ */
+static inline eckey* cli_eckey_from_privkey(char* private_key)
+{
+#ifdef DOGECOIN_TS
+    dogecoin_eckey_context* kctx = dogecoin_eckey_context_new();
+    eckey* key = new_eckey_from_privkey_ts(kctx, private_key);
+    dogecoin_eckey_context_free(kctx);
+    return key;
+#else
+    return new_eckey_from_privkey(private_key);
+#endif
+}
+
+/* Wallet */
+
+/**
+ * @brief Initialize a wallet, binding it to the thread-safe context in the
+ * `_ts` build.
+ *
+ * @param ctx The thread-safe context (used only in the `_ts` build).
+ * @param chain The chain parameters.
+ * @param address The wallet address.
+ * @param name The wallet name.
+ * @param opts The wallet options.
+ *
+ * @return The initialized wallet, or NULL on failure.
+ */
+static inline dogecoin_wallet* cli_wallet_init(dogecoin_ctx* ctx, const dogecoin_chainparams* chain,
+                                               const char* address, const char* name,
+                                               const dogecoin_wallet_opts* opts)
+{
+#ifdef DOGECOIN_TS
+    return dogecoin_wallet_init_ts(ctx, chain, address, name, opts);
+#else
+    (void)ctx;
+    return dogecoin_wallet_init(chain, address, name, opts);
+#endif
+}
+
+/**
+ * @brief Allocate a new wallet, enabling thread-safe mode in the `_ts` build.
+ *
+ * @param ctx The thread-safe context (used only in the `_ts` build).
+ * @param params The chain parameters.
+ *
+ * @return The new wallet, or NULL on failure.
+ */
+static inline dogecoin_wallet* cli_wallet_new(dogecoin_ctx* ctx, const dogecoin_chainparams* params)
+{
+    dogecoin_wallet* wallet = dogecoin_wallet_new(params);
+#ifdef DOGECOIN_TS
+    if (wallet) dogecoin_wallet_enable_thread_safe(wallet, ctx);
+#else
+    (void)ctx;
+#endif
+    return wallet;
+}
+
+/**
+ * @brief Free a wallet allocated through the CLI wallet helpers.
+ *
+ * @param wallet The wallet to free.
+ *
+ * @return Nothing.
+ */
+static inline void cli_wallet_free(dogecoin_wallet* wallet)
+{
+#ifdef DOGECOIN_TS
+    dogecoin_wallet_free_ts(wallet);
+#else
+    dogecoin_wallet_free(wallet);
+#endif
+}
+
+#endif /* __LIBDOGECOIN_THREADSAFE_H__ */

--- a/include/dogecoin/transaction.h
+++ b/include/dogecoin/transaction.h
@@ -45,24 +45,33 @@ typedef struct working_transaction {
     UT_hash_handle hh;
 } working_transaction;
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-static working_transaction *transactions = NULL;
-#pragma GCC diagnostic pop
+typedef struct dogecoin_transaction_context {
+    working_transaction* transactions;
+} dogecoin_transaction_context;
+
+struct dogecoin_wallet_;
+
 // instantiates a new transaction
 LIBDOGECOIN_API working_transaction* new_transaction();
+LIBDOGECOIN_API working_transaction* new_transaction_ts(dogecoin_transaction_context* ctx);
 
 LIBDOGECOIN_API void add_transaction(working_transaction *working_tx);
+LIBDOGECOIN_API void add_transaction_ts(dogecoin_transaction_context* ctx, working_transaction *working_tx);
 
 LIBDOGECOIN_API working_transaction* find_transaction(int idx);
+LIBDOGECOIN_API working_transaction* find_transaction_ts(dogecoin_transaction_context* ctx, int idx);
 
 LIBDOGECOIN_API void remove_transaction(working_transaction *working_tx);
+LIBDOGECOIN_API void remove_transaction_ts(dogecoin_transaction_context* ctx, working_transaction *working_tx);
 
 LIBDOGECOIN_API void remove_all();
+LIBDOGECOIN_API void remove_all_ts(dogecoin_transaction_context* ctx);
 
 LIBDOGECOIN_API void print_transactions();
 
 LIBDOGECOIN_API void count_transactions();
+LIBDOGECOIN_API int get_transaction_count(void);
+LIBDOGECOIN_API int get_transaction_count_ts(dogecoin_transaction_context* ctx);
 
 LIBDOGECOIN_API int by_id();
 
@@ -73,20 +82,44 @@ LIBDOGECOIN_API const char *get_raw_tx(const char *prompt_tx);
 LIBDOGECOIN_API const char *get_private_key(const char *prompt_key);
 
 LIBDOGECOIN_API int start_transaction(); // #returns  an index of a transaction to build in memory.  (1, 2, etc) ..
+LIBDOGECOIN_API int start_transaction_ts(dogecoin_transaction_context* ctx);
+
+LIBDOGECOIN_API dogecoin_transaction_context* dogecoin_transaction_context_new(void);
+LIBDOGECOIN_API void dogecoin_transaction_context_free(dogecoin_transaction_context* ctx);
+
+/* Returns the per-thread default transaction context that the non-`_ts`
+ * convenience wrappers (and the index-based transaction API) operate on. This
+ * lets callers invoke the `_ts` transaction-context API explicitly against the
+ * same registry, rather than going through the non-`_ts` wrappers. */
+LIBDOGECOIN_API dogecoin_transaction_context* dogecoin_transaction_context_default(void);
 
 LIBDOGECOIN_API int save_raw_transaction(int txindex, const char* hexadecimal_transaction);
+/* THREAD-SAFE variant - operates on the supplied transaction context and
+   acquires the working transaction's per-object mutex. */
+LIBDOGECOIN_API int save_raw_transaction_ts(dogecoin_transaction_context* ctx, int txindex, const char* hexadecimal_transaction);
 
 LIBDOGECOIN_API int add_utxo(int txindex, char* hex_utxo_txid, int vout); // #returns 1 if success.
+/* THREAD-SAFE variant - routes the input through dogecoin_tx_add_input_ts. */
+LIBDOGECOIN_API int add_utxo_ts(dogecoin_transaction_context* ctx, int txindex, char* hex_utxo_txid, int vout);
 
 LIBDOGECOIN_API int add_output(int txindex, char* destinationaddress, char* amount);
+/* THREAD-SAFE variant - routes the output through dogecoin_tx_add_output_ts. */
+LIBDOGECOIN_API int add_output_ts(dogecoin_transaction_context* ctx, int txindex, char* destinationaddress, char* amount);
 
 // 'closes the inputs', specifies the recipient, specifies the amnt-to-subtract-as-fee, and returns the raw tx..
 // out_dogeamount == just an echoback of the total amount specified in the addutxos for verification
 LIBDOGECOIN_API char* finalize_transaction(int txindex, char* destinationaddress, char* subtractedfee, char* out_dogeamount_for_verification, char* public_key);
+/* THREAD-SAFE variant - adds change via dogecoin_tx_add_output_ts and runs the
+   dogecoin_tx_finalize_ts integrity pass before serializing. */
+LIBDOGECOIN_API char* finalize_transaction_ts(dogecoin_transaction_context* ctx, int txindex, char* destinationaddress, char* subtractedfee, char* out_dogeamount_for_verification, char* public_key);
 
 LIBDOGECOIN_API char* get_raw_transaction(int txindex); // #returns 0 if not closed, returns rawtx again if closed/created.
+/* THREAD-SAFE variant - serializes under the working transaction's mutex. */
+LIBDOGECOIN_API char* get_raw_transaction_ts(dogecoin_transaction_context* ctx, int txindex);
 
 LIBDOGECOIN_API void clear_transaction(int txindex); // #clears a tx in memory. (overwrites)
+/* THREAD-SAFE variant - removes the entry from the supplied context. */
+LIBDOGECOIN_API void clear_transaction_ts(dogecoin_transaction_context* ctx, int txindex);
 
 // sign a given inputted transaction with a given private key, and return a hex signed transaction.
 // we may want to add such things to 'advanced' section:
@@ -112,6 +145,20 @@ LIBDOGECOIN_API int sign_indexed_raw_transaction_ex(int txindex, int inputindex,
 LIBDOGECOIN_API int sign_transaction_ex(int txindex, const char* script_pubkey, const char* privkey, char* buf, size_t buf_cap);
 
 LIBDOGECOIN_API int sign_transaction_w_privkey_ex(int txindex, const char* privkey, char* buf, size_t buf_cap);
+
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API dogecoin_tx* dogecoin_tx_new_ts(void);
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API void dogecoin_tx_free_ts(dogecoin_tx* tx);
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API int dogecoin_tx_add_input_ts(dogecoin_tx* tx, const dogecoin_tx_in* tx_in);
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API int dogecoin_tx_add_output_ts(dogecoin_tx* tx, const dogecoin_tx_out* tx_out);
+/* THREAD-SAFE variant - uses internal mutex */
+/* passphrase is currently reserved for future encrypted-wallet integration */
+LIBDOGECOIN_API int dogecoin_tx_sign_ts(dogecoin_tx* tx, struct dogecoin_wallet_* wallet, const char* passphrase);
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API int dogecoin_tx_finalize_ts(dogecoin_tx* tx);
 
 LIBDOGECOIN_END_DECL
 

--- a/include/dogecoin/tx.h
+++ b/include/dogecoin/tx.h
@@ -67,6 +67,8 @@ typedef struct dogecoin_tx_ {
     vector_t* vin;
     vector_t* vout;
     uint32_t locktime;
+    dogecoin_bool thread_safe;
+    dogecoin_mutex_t lock;
 } dogecoin_tx;
 
 //!p2pkh utilities
@@ -90,7 +92,7 @@ LIBDOGECOIN_API void dogecoin_tx_out_copy(dogecoin_tx_out* dest, const dogecoin_
 LIBDOGECOIN_API dogecoin_bool dogecoin_tx_out_deserialize(dogecoin_tx_out* tx_out, struct const_buffer* buf);
 LIBDOGECOIN_API void dogecoin_tx_out_serialize(cstring* s, const dogecoin_tx_out* tx_out);
 
-//!create a new tx input
+/* NOT THREAD-SAFE - use dogecoin_tx_new_ts() for shared transaction mutation */
 LIBDOGECOIN_API dogecoin_tx* dogecoin_tx_new();
 LIBDOGECOIN_API void dogecoin_tx_free(dogecoin_tx* tx);
 LIBDOGECOIN_API void dogecoin_tx_copy(dogecoin_tx* dest, const dogecoin_tx* src);

--- a/include/dogecoin/vector.h
+++ b/include/dogecoin/vector.h
@@ -33,16 +33,6 @@
 
 LIBDOGECOIN_BEGIN_DECL
 
-typedef struct vector_t {
-    void** data;  /* array of pointers */
-    size_t len;   /* array element count */
-    size_t alloc; /* allocated array elements */
-
-    void (*elem_free_f)(void*);
-} vector_t;
-
-#define vector_idx(vec, idx) vec->data[idx]
-
 LIBDOGECOIN_API vector_t* vector_new(size_t res, void (*free_f)(void*));
 LIBDOGECOIN_API void vector_free(vector_t* vec, dogecoin_bool free_array);
 

--- a/include/dogecoin/wallet.h
+++ b/include/dogecoin/wallet.h
@@ -67,7 +67,7 @@ typedef struct dogecoin_utxo_ {
 
 DISABLE_WARNING_PUSH
 DISABLE_WARNING(-Wunused-variable)
-static dogecoin_utxo* utxos = NULL;
+static DOGECOIN_THREAD_LOCAL dogecoin_utxo* utxos = NULL;
 DISABLE_WARNING_POP
 
 /** wallet init options */
@@ -99,6 +99,9 @@ typedef struct dogecoin_wallet_ {
     void* wtxes_rbtree;
     vector_t *waddr_vector; //points to the addr objects managed by the waddr_rbtree [in order]
     void* waddr_rbtree;
+    dogecoin_ctx* ctx;
+    dogecoin_bool thread_safe;
+    dogecoin_mutex_t lock;
 } dogecoin_wallet;
 
 typedef struct dogecoin_wtx_ {
@@ -151,19 +154,34 @@ LIBDOGECOIN_API dogecoin_output* dogecoin_wallet_output_new();
 LIBDOGECOIN_API void dogecoin_wallet_output_free(dogecoin_output* output);
 /** ------------------------------------ */
 
+/* NOT THREAD-SAFE - use _ts variant for shared wallet access */
 LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_new(const dogecoin_chainparams *params);
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_new_ts(dogecoin_ctx* ctx);
 LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const char* address, const char* name, const dogecoin_wallet_opts* opts);
+/* THREAD-SAFE variant of dogecoin_wallet_init - keeps the explicit chain */
+LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_init_ts(dogecoin_ctx* ctx, const dogecoin_chainparams* chain, const char* address, const char* name, const dogecoin_wallet_opts* opts);
+/* Promote an existing wallet to thread-safe (attach ctx + init mutex). Idempotent. */
+LIBDOGECOIN_API int dogecoin_wallet_enable_thread_safe(dogecoin_wallet* wallet, dogecoin_ctx* ctx);
 LIBDOGECOIN_API void print_utxos(dogecoin_wallet* wallet);
 LIBDOGECOIN_API void dogecoin_wallet_free(dogecoin_wallet* wallet);
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API dogecoin_wallet* dogecoin_wallet_load_ts(dogecoin_ctx* ctx, const char* file);
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API void dogecoin_wallet_free_ts(dogecoin_wallet* wallet);
 
 /** load the wallet, sets masterkey, sets next_childindex */
+/* NOT THREAD-SAFE - use dogecoin_wallet_load_ts() for shared wallet access */
 LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_load(dogecoin_wallet* wallet, const char* file_path, int *error, dogecoin_bool *created, dogecoin_bool prompt);
 
 /** load the wallet and replace a record */
 LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_replace(dogecoin_wallet* wallet, const char* file_path, cstring* record, uint8_t record_type, int *error);
 
 /** writes the wallet state to disk */
+/* NOT THREAD-SAFE - use dogecoin_wallet_save_ts() for shared wallet access */
 LIBDOGECOIN_API dogecoin_bool dogecoin_wallet_flush(dogecoin_wallet* wallet);
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API int dogecoin_wallet_save_ts(dogecoin_wallet* wallet);
 
 /** set the master key of new created wallet
  consuming app needs to ensure that we don't override exiting masterkeys */
@@ -172,6 +190,10 @@ LIBDOGECOIN_API void dogecoin_wallet_set_master_key_copy(dogecoin_wallet* wallet
 /** derives the next child hdnode and derives an address (memory is owned by the wallet) */
 LIBDOGECOIN_API dogecoin_wallet_addr* dogecoin_wallet_next_addr(dogecoin_wallet* wallet);
 LIBDOGECOIN_API dogecoin_wallet_addr* dogecoin_wallet_next_bip44_addr(dogecoin_wallet* wallet);
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API int dogecoin_wallet_add_hd_account_ts(dogecoin_wallet* wallet, uint32_t account);
+/* THREAD-SAFE variant - uses internal mutex */
+LIBDOGECOIN_API int dogecoin_wallet_get_address_ts(dogecoin_wallet* wallet, char* address, size_t len, uint32_t account, uint32_t index, dogecoin_bool change);
 LIBDOGECOIN_API dogecoin_bool dogecoin_p2pkh_address_to_wallet_pubkeyhash(const char* address_in, dogecoin_wallet_addr* addr, dogecoin_wallet* wallet);
 LIBDOGECOIN_API dogecoin_wallet_addr* dogecoin_p2pkh_address_to_wallet(const char* address_in, dogecoin_wallet* wallet);
 

--- a/src/bip39.c
+++ b/src/bip39.c
@@ -38,6 +38,9 @@
 #define WINVER 0x0600
 #endif
 #include <windows.h>
+/* WIN32_LEAN_AND_MEAN (defined upstream) strips winnls.h from windows.h;
+ * include it explicitly so NormalizeString and NormalizationKD are declared. */
+#include <winnls.h>
 #endif
 
 /*

--- a/src/cli/sendtx.c
+++ b/src/cli/sendtx.c
@@ -58,6 +58,7 @@
 #include <dogecoin/tool.h>
 #include <dogecoin/tx.h>
 #include <dogecoin/utils.h>
+#include <dogecoin/threadsafe.h>
 
 static struct option long_options[] = {
         {"testnet", no_argument, NULL, 't'},
@@ -148,8 +149,12 @@ int main(int argc, char* argv[]) {
     if (data == NULL) {
         return showError("Transaction is invalid or too large.\n");
         }
+
+    dogecoin_ctx* ts_ctx = cli_ts_context_start("sendtx", chain == &dogecoin_chainparams_test);
+
     size_t data_hex_len = strspn(data, VALID_HEX_CHARS);
     if (data_hex_len == 0 || (data_hex_len % 2) != 0 || data[data_hex_len] != '\0' || data_hex_len > DOGECOIN_MAX_TX_HEX_LEN - 1) {
+        cli_ts_context_finish(ts_ctx);
         return showError("Transaction is invalid or too large.\n");
         }
     uint8_t* data_bin = dogecoin_malloc(data_hex_len / 2 + 1);
@@ -169,5 +174,6 @@ int main(int argc, char* argv[]) {
     dogecoin_free(data_bin);
     dogecoin_tx_free(tx);
 
+    cli_ts_context_finish(ts_ctx);
     return ret;
     }

--- a/src/cli/spvnode.c
+++ b/src/cli/spvnode.c
@@ -78,6 +78,7 @@
 #include <dogecoin/tx.h>
 #include <dogecoin/utils.h>
 #include <dogecoin/wallet.h>
+#include <dogecoin/threadsafe.h>
 
 #ifndef WIN32
 #define BD_NO_CHDIR          01 /* Don't chdir ("/") */
@@ -575,6 +576,7 @@ int main(int argc, char* argv[]) {
 
     if (strcmp(data, "scan") == 0) {
         dogecoin_ecc_start();
+        dogecoin_ctx* ts_ctx = cli_ts_context_start("spvnode", chain == &dogecoin_chainparams_test);
         in_memory_headers = (dbfile && ((strcmp(dbfile, "0") == 0) || (strcmp(dbfile, "no") == 0)));
         dogecoin_spv_client* client = dogecoin_spv_client_new(chain, debug, in_memory_headers, use_checkpoint, full_sync, maxnodes, http_server);
 
@@ -597,7 +599,8 @@ int main(int argc, char* argv[]) {
             .master_key = master_key,
             .prompt = prompt
         };
-        dogecoin_wallet* wallet = dogecoin_wallet_init(
+        dogecoin_wallet* wallet = cli_wallet_init(
+            ts_ctx,
             chain,
             address,
             name,
@@ -609,10 +612,14 @@ int main(int argc, char* argv[]) {
                 dogecoin_mem_zero (pass, strlen(pass));
                 dogecoin_free(pass);
                 }
+            cli_ts_context_finish(ts_ctx);
             dogecoin_spv_client_free(client);
             dogecoin_ecc_stop();
             return EXIT_FAILURE;
         }
+        /* The wallet now holds its own reference to the thread-safe context
+           (released by dogecoin_wallet_free), so drop our standalone one. */
+        cli_ts_context_finish(ts_ctx);
         // clear and free the passphrase
         if (pass) {
             dogecoin_mem_zero (pass, strlen(pass));
@@ -654,7 +661,7 @@ int main(int argc, char* argv[]) {
             dogecoin_bip37_filter* filter = dogecoin_bip37_filter_new(0, 1); /* random tweak, UPDATE_ALL */
             if (!filter) {
                 printf("Failed to initialize BIP37 bloom filter\n");
-                dogecoin_wallet_free(wallet);
+                cli_wallet_free(wallet);
                 dogecoin_spv_client_free(client);
                 dogecoin_ecc_stop();
                 return EXIT_FAILURE;
@@ -742,7 +749,7 @@ int main(int argc, char* argv[]) {
         if (!response) {
             printf("Could not load or create headers database...aborting\n");
 #if WITH_WALLET
-            dogecoin_wallet_free(wallet);
+            cli_wallet_free(wallet);
 #endif
             dogecoin_spv_client_free(client);
             dogecoin_ecc_stop();
@@ -828,7 +835,7 @@ int main(int argc, char* argv[]) {
                 }
                 dogecoin_spv_client_free(client);
 #if WITH_WALLET
-                dogecoin_wallet_free(wallet);
+                cli_wallet_free(wallet);
 #endif
                 dogecoin_ecc_stop();
                 return EXIT_FAILURE;
@@ -840,7 +847,7 @@ int main(int argc, char* argv[]) {
             printf("done\n");
             ret = EXIT_SUCCESS;
 #if WITH_WALLET
-            dogecoin_wallet_free(wallet);
+            cli_wallet_free(wallet);
 #endif
             }
         dogecoin_ecc_stop();
@@ -927,7 +934,7 @@ int main(int argc, char* argv[]) {
                 printf( "File 'tmp.bin' copied to '%s'\n", tmp->filename);
             }
         }
-        dogecoin_wallet_free(tmp);
+        cli_wallet_free(tmp);
         dogecoin_free(address_copy);
     }
 

--- a/src/cli/such.c
+++ b/src/cli/such.c
@@ -83,18 +83,19 @@ static const char* SUCH_MULTISIG_REDEEM_SCRIPT_LABEL = "multisig redeem script: 
 static const char* SUCH_MULTISIG_P2SH_ADDRESS_LABEL = "multisig p2sh address: %s\n";
 
 // ******************************** SUCH -C TRANSACTION MENU ********************************
+#include <dogecoin/threadsafe.h>
 #ifdef WITH_NET
 #include <dogecoin/net.h>
 void broadcasting_menu(int txindex, int is_testnet) {
     int running = 1;
     int selected = -1;
     const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
-    working_transaction* tx = find_transaction(txindex);
-    char* raw_hexadecimal_tx = get_raw_transaction(txindex);
-    int length = HASH_COUNT(transactions);
+    working_transaction* tx = cli_find_transaction(txindex);
+    char* raw_hexadecimal_tx = cli_get_raw_transaction(txindex);
     while (running) {
+        int length = cli_get_transaction_count();
         printf("length: %d\n", length);
-        for (int i = 0; i <= length; i++) {
+        for (int i = 0; i < length; i++) {
             printf("\n--------------------------------\n");
             printf("transaction to broadcast: %s\n", raw_hexadecimal_tx);
             selected == i ? printf("confirm:         [X]\n") : 0;
@@ -191,7 +192,7 @@ void signing_menu(int txindex, int is_testnet) {
                              getl("redeem script hex (blank for single-key P2PKH)"));
 
                     if (choice == 1) {
-                        raw_hexadecimal_tx = get_raw_transaction(txindex);
+                        raw_hexadecimal_tx = cli_get_raw_transaction(txindex);
                     } else {
                         raw_hexadecimal_tx = (char*)get_raw_tx("raw transaction");
                     }
@@ -228,7 +229,7 @@ void signing_menu(int txindex, int is_testnet) {
                     break;
                 }
                 case 3:
-                    printf("raw_tx: %s\n", get_raw_transaction(txindex));
+                    printf("raw_tx: %s\n", cli_get_raw_transaction(txindex));
                     break;
                 case 4:
                     running = 0;
@@ -335,32 +336,32 @@ void sub_menu(int txindex, int is_testnet) {
         printf(" 9. main menu\n\n");
         switch (atoi(getl("command"))) {
                 case 1:
-                    printf("raw_tx: %s\n", get_raw_transaction(txindex));
+                    printf("raw_tx: %s\n", cli_get_raw_transaction(txindex));
                     temp_vout_index = atoi(getl("vout index")); // 1
                     temp_hex_utxo_txid = (char*)getl("txid"); // b4455e7b7b7acb51fb6feba7a2702c42a5100f61f61abafa31851ed6ae076074 & 42113bdc65fc2943cf0359ea1a24ced0b6b0b5290db4c63a3329c6601c4616e2
-                    add_utxo(txindex, temp_hex_utxo_txid, temp_vout_index);
-                    printf("raw_tx: %s\n", get_raw_transaction(txindex));
+                    cli_add_utxo(txindex, temp_hex_utxo_txid, temp_vout_index);
+                    printf("raw_tx: %s\n", cli_get_raw_transaction(txindex));
                     break;
                 case 2:
                     /* getl() returns a pointer into a single static buffer,
                      * so the second getl() below would overwrite the amount
-                     * before add_output() reads it. Snapshot it first. */
+                     * before cli_add_output() reads it. Snapshot it first. */
                     {
                         char temp_amt_buf[64];
                         const char* _amt = getl("amount to send to destination address"); // 5
                         snprintf(temp_amt_buf, sizeof(temp_amt_buf), "%s", _amt);
                         temp_ext_p2pkh = getl("destination address"); // nbGfXLskPh7eM1iG5zz5EfDkkNTo9TRmde
                         printf("destination: %s\n", temp_ext_p2pkh);
-                        printf("addout success: %d\n", add_output(txindex, (char*)temp_ext_p2pkh, temp_amt_buf));
+                        printf("addout success: %d\n", cli_add_output(txindex, (char*)temp_ext_p2pkh, temp_amt_buf));
                     }
-                    char* str = get_raw_transaction(txindex);
+                    char* str = cli_get_raw_transaction(txindex);
                     printf("raw_tx: %s\n", str);
                     break;
                 case 3:
                     /* getl() returns a pointer into a single static buffer,
                      * so each subsequent call overwrites the previous return
                      * value. Snapshot every prompt into its own buffer before
-                     * passing them to finalize_transaction(). */
+                     * passing them to cli_finalize_transaction(). */
                     {
                         char out_addr_buf[128], fee_buf[64], total_buf[64], change_buf[128];
                         snprintf(out_addr_buf, sizeof(out_addr_buf), "%s",
@@ -371,7 +372,7 @@ void sub_menu(int txindex, int is_testnet) {
                                  getl("total amount for verification"));
                         snprintf(change_buf, sizeof(change_buf), "%s",
                                  getl("senders address"));
-                        raw_hexadecimal_transaction = finalize_transaction(
+                        raw_hexadecimal_transaction = cli_finalize_transaction(
                             txindex, out_addr_buf, fee_buf, total_buf, change_buf);
                     }
                     printf("raw_tx: %s\n", raw_hexadecimal_transaction);
@@ -391,7 +392,7 @@ void sub_menu(int txindex, int is_testnet) {
                     break;
 #endif
                 case 8:
-                    printf("raw_tx: %s\n", get_raw_transaction(txindex));
+                    printf("raw_tx: %s\n", cli_get_raw_transaction(txindex));
                     break;
                 case 9:
                     running = 0;
@@ -405,7 +406,7 @@ void sub_menu(int txindex, int is_testnet) {
 void transaction_input_menu(int txindex, int is_testnet) {
 #pragma GCC diagnostic pop
     int running_transaction_input_menu = 1;
-    working_transaction* tx = find_transaction(txindex);
+    working_transaction* tx = cli_find_transaction(txindex);
     while (running_transaction_input_menu) {
         int length = tx->transaction->vin->len;
         int selected = -1;
@@ -455,7 +456,7 @@ void transaction_input_menu(int txindex, int is_testnet) {
                                         script_pubkey = dogecoin_private_key_wif_to_pubkey_hash(private_key_wif);
                                         cstr_erase(tx_in->script_sig, 0, tx_in->script_sig->len);
                                         // 76a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac
-                                        raw_hexadecimal_tx = get_raw_transaction(txindex);
+                                        raw_hexadecimal_tx = cli_get_raw_transaction(txindex);
                                         printf("raw_hexadecimal_transaction: %s\n", raw_hexadecimal_tx);
                                         // 76a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac
                                         if (!sign_indexed_raw_transaction(txindex, input_to_sign, raw_hexadecimal_tx, script_pubkey, 1, private_key_wif)) {
@@ -507,7 +508,7 @@ void transaction_output_menu(int txindex, int is_testnet) {
         uint64_t koinu_amount;
         uint64_t tx_out_total = 0;
         const dogecoin_chainparams* chain = is_testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
-        working_transaction* tx = find_transaction(txindex);
+        working_transaction* tx = cli_find_transaction(txindex);
         int length = tx->transaction->vout->len;
         int selected = -1;
         printf("length: %d\n", length);
@@ -637,7 +638,7 @@ void main_menu() {
     wow();
 
     // load existing testnet transaction into memory for demonstration purposes.
-    save_raw_transaction(start_transaction(), "0100000002746007aed61e8531faba1af6610f10a5422c70a2a7eb6ffb51cb7a7b7b5e45b40100000000ffffffffe216461c60c629333ac6b40d29b5b0b6d0ce241aea5903cf4329fc65dc3b11420100000000ffffffff020065cd1d000000001976a9144da2f8202789567d402f7f717c01d98837e4325488ac30b4b529000000001976a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac00000000");
+    cli_save_raw_transaction(cli_start_transaction(), "0100000002746007aed61e8531faba1af6610f10a5422c70a2a7eb6ffb51cb7a7b7b5e45b40100000000ffffffffe216461c60c629333ac6b40d29b5b0b6d0ce241aea5903cf4329fc65dc3b11420100000000ffffffff020065cd1d000000001976a9144da2f8202789567d402f7f717c01d98837e4325488ac30b4b529000000001976a914d8c43e6f68ca4ea1e9b93da2d1e3a95118fa4a7c88ac00000000");
     while (running) {
         printf("\nsuch transaction: \n\n");
         printf(" 1. add transaction\n");
@@ -658,11 +659,11 @@ void main_menu() {
 #endif
         switch (atoi(getl("\ncommand"))) {
                 case 1:
-                    sub_menu(start_transaction(), is_testnet);
+                    sub_menu(cli_start_transaction(), is_testnet);
                     break;
                 case 2:
                     temp = atoi(getl("ID of transaction to edit"));
-                    s = find_transaction(temp);
+                    s = cli_find_transaction(temp);
                     if (s) {
                         edit_menu(temp, is_testnet);
                         }
@@ -671,12 +672,12 @@ void main_menu() {
                         }
                     break;
                 case 3:
-                    s = find_transaction(atoi(getl("ID to find")));
-                    s ? printf("transaction: %s\n", get_raw_transaction(s->idx)) : printf("\nno transaction found with that id. please try again!\n");
+                    s = cli_find_transaction(atoi(getl("ID to find")));
+                    s ? printf("transaction: %s\n", cli_get_raw_transaction(s->idx)) : printf("\nno transaction found with that id. please try again!\n");
                     break;
                 case 4:
                     temp = atoi(getl("ID of transaction to sign"));
-                    s = find_transaction(temp);
+                    s = cli_find_transaction(temp);
                     if (s) {
                         signing_menu(temp, is_testnet);
                         }
@@ -685,27 +686,27 @@ void main_menu() {
                         }
                     break;
                 case 5:
-                    s = find_transaction(atoi(getl("ID to delete")));
+                    s = cli_find_transaction(atoi(getl("ID to delete")));
                     if (s) {
-                        remove_transaction(s);
+                        cli_remove_transaction(s);
                         }
                     else {
                         printf("\nno transaction found with that id. please try again!\n");
                         }
                     break;
                 case 6:
-                    remove_all();
+                    cli_remove_all();
                     break;
                 case 7:
                     count_transactions();
                     print_transactions();
                     break;
                 case 8:
-                    txindex = start_transaction();
-                    int res = save_raw_transaction(txindex, get_raw_tx("raw transaction"));
+                    txindex = cli_start_transaction();
+                    int res = cli_save_raw_transaction(txindex, get_raw_tx("raw transaction"));
                     if (!res) {
                         printf("error saving transaction!\n");
-                        clear_transaction(txindex);
+                        cli_clear_transaction(txindex);
                         }
                     else {
                         printf("successfully saved raw transaction to memory for the session!\n");
@@ -715,7 +716,7 @@ void main_menu() {
 #ifdef WITH_NET
                 case 9:
                     temp = atoi(getl("ID of transaction to edit"));
-                    s = find_transaction(temp);
+                    s = cli_find_transaction(temp);
                     if (s) {
                         broadcasting_menu(temp, is_testnet);
                         }
@@ -739,7 +740,7 @@ void main_menu() {
 #endif
             }
         }
-    remove_all();
+    cli_remove_all();
     }
 
 // ******************************** END TRANSACTION MENU ********************************
@@ -1300,6 +1301,13 @@ int main(int argc, char* argv[])
 
     /* start ECC context */
     dogecoin_ecc_start();
+
+    /* Exercise the thread-safe context API (refcount mutex) in the `_ts`
+       build. such has no long-lived context-owned object, so the context is
+       created, queried and released here; the thread-safe transaction builder,
+       transaction-context and eckey-context APIs are routed via the cli_*
+       wrappers below. */
+    cli_ts_context_finish(cli_ts_context_start("such", false));
 
     /* WIF / extended-key length sanity check for commands that consume -p as
        a base58-encoded private key.  PQC carrier and PQC signing commands
@@ -2334,7 +2342,7 @@ int main(int argc, char* argv[])
             return showError("tx too large (max 100kb)\n");
             }
 
-        eckey* key = new_eckey_from_privkey(pkey);
+        eckey* key = cli_eckey_from_privkey(pkey);
         char* sig = sign_message(key->private_key_wif, txhex);
         printf("message: %s\n", txhex);
         printf("content: %s\n", sig);

--- a/src/context.c
+++ b/src/context.c
@@ -1,0 +1,472 @@
+/*
+
+ The MIT License (MIT)
+
+ Copyright (c) 2024-2026 The Dogecoin Foundation
+
+ Permission is hereby granted, free of charge, to any person obtaining
+ a copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+ OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+#include <dogecoin/libdogecoin.h>
+#include <dogecoin/mem.h>
+#include <dogecoin/random.h>
+
+#include "secp256k1/include/secp256k1.h"
+
+#ifdef _WIN32
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
+
+struct dogecoin_transaction_context* dogecoin_transaction_context_new(void);
+void dogecoin_transaction_context_free(struct dogecoin_transaction_context* ctx);
+struct dogecoin_eckey_context* dogecoin_eckey_context_new(void);
+void dogecoin_eckey_context_free(struct dogecoin_eckey_context* ctx);
+
+/**
+ * @brief Returns the platform mutex size used to guard the refcount.
+ *
+ * Selects the size of the underlying critical section (Windows) or
+ * pthread mutex (POSIX) that backs the context reference-count lock.
+ *
+ * @return The number of bytes to allocate for the refcount lock.
+ */
+static size_t dogecoin_refcount_lock_size(void)
+{
+#ifdef _WIN32
+    return sizeof(CRITICAL_SECTION);
+#else
+    return sizeof(pthread_mutex_t);
+#endif
+}
+
+/**
+ * @brief Releases every owned subsystem held by a context.
+ *
+ * Frees the transaction, eckey, RNG and secp256k1 sub-contexts as well as the
+ * refcount lock, and resets the pointers to NULL. Does not free the context
+ * structure itself.
+ *
+ * @param ctx The context whose members should be released. May be NULL.
+ *
+ * @return Nothing.
+ */
+static void dogecoin_context_cleanup(dogecoin_context* ctx)
+{
+    if (!ctx) return;
+    if (ctx->tx_ctx) dogecoin_transaction_context_free(ctx->tx_ctx);
+    if (ctx->key_ctx) dogecoin_eckey_context_free(ctx->key_ctx);
+    if (ctx->rng_state) free_fast_random_context((struct fast_random_context*)ctx->rng_state);
+    if (ctx->ecc_ctx) secp256k1_context_destroy((secp256k1_context*)ctx->ecc_ctx);
+    if (ctx->refcount_lock) {
+#ifdef _WIN32
+        DeleteCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
+#else
+        pthread_mutex_destroy((pthread_mutex_t*)ctx->refcount_lock);
+#endif
+        dogecoin_free(ctx->refcount_lock);
+    }
+    ctx->tx_ctx = NULL;
+    ctx->key_ctx = NULL;
+    ctx->rng_state = NULL;
+    ctx->ecc_ctx = NULL;
+    ctx->refcount_lock = NULL;
+}
+
+/**
+ * @brief Clears the last-error state stored on a context.
+ *
+ * @param ctx The context whose error code and message should be reset. May be NULL.
+ *
+ * @return Nothing.
+ */
+static void dogecoin_context_zero_error(dogecoin_context* ctx)
+{
+    if (!ctx) return;
+    ctx->error_code = 0;
+    ctx->last_error[0] = '\0';
+}
+
+/**
+ * @brief Allocates and initializes a new stateless libdogecoin context.
+ *
+ * Creates the per-context secp256k1 context (seeded with fresh randomness), the
+ * fast RNG state, and the transaction and eckey sub-contexts, and initializes
+ * the refcount lock with an initial reference count of 1.
+ *
+ * @param testnet    Selects testnet chain parameters when true, mainnet otherwise.
+ * @param enable_net Records whether networking is intended for this context.
+ *
+ * @return A pointer to the new context, or NULL on allocation/initialization failure.
+ */
+dogecoin_context* dogecoin_context_new(dogecoin_bool testnet, dogecoin_bool enable_net)
+{
+    dogecoin_context* ctx = (dogecoin_context*)dogecoin_calloc(1, sizeof(*ctx));
+    if (!ctx) return NULL;
+    ctx->chain_params = testnet ? &dogecoin_chainparams_test : &dogecoin_chainparams_main;
+    ctx->enable_net = enable_net ? 1 : 0;
+    ctx->refcount = 1;
+    ctx->refcount_lock = dogecoin_calloc(1, dogecoin_refcount_lock_size());
+    if (!ctx->refcount_lock) {
+        dogecoin_free(ctx);
+        return NULL;
+    }
+#ifdef _WIN32
+    InitializeCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
+#else
+    if (pthread_mutex_init((pthread_mutex_t*)ctx->refcount_lock, NULL) != 0) {
+        dogecoin_free(ctx->refcount_lock);
+        ctx->refcount_lock = NULL;
+        dogecoin_free(ctx);
+        return NULL;
+    }
+#endif
+    ctx->ecc_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
+    if (!ctx->ecc_ctx) {
+        dogecoin_context_cleanup(ctx);
+        dogecoin_free(ctx);
+        return NULL;
+    }
+    union {
+        uint256_t u256;
+        uint8_t bytes[32];
+    } randomization_seed;
+    if (!dogecoin_random_bytes(randomization_seed.bytes, sizeof(randomization_seed.bytes), 0) ||
+        !secp256k1_context_randomize((secp256k1_context*)ctx->ecc_ctx, randomization_seed.bytes)) {
+        dogecoin_mem_zero(randomization_seed.bytes, sizeof(randomization_seed.bytes));
+        dogecoin_context_cleanup(ctx);
+        dogecoin_free(ctx);
+        return NULL;
+    }
+    const uint256_t* rng_init_seed = (const uint256_t*)&randomization_seed.u256;
+    ctx->rng_state = init_fast_random_context(false, rng_init_seed);
+    dogecoin_mem_zero(randomization_seed.bytes, sizeof(randomization_seed.bytes));
+    ctx->tx_ctx = dogecoin_transaction_context_new();
+    ctx->key_ctx = dogecoin_eckey_context_new();
+    if (!ctx->rng_state || !ctx->tx_ctx || !ctx->key_ctx) {
+        dogecoin_context_cleanup(ctx);
+        dogecoin_free(ctx);
+        return NULL;
+    }
+    dogecoin_context_zero_error(ctx);
+    return ctx;
+}
+
+/**
+ * @brief Atomically increments the reference count of a context.
+ *
+ * Acquires an additional owning reference; each call must be balanced by a
+ * matching dogecoin_context_release().
+ *
+ * @param ctx The context to retain. No-op if NULL or uninitialized.
+ *
+ * @return Nothing.
+ */
+void dogecoin_context_acquire(dogecoin_context* ctx)
+{
+    if (!ctx) return;
+    if (!ctx->refcount_lock) return;
+#ifdef _WIN32
+    EnterCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
+#else
+    pthread_mutex_lock((pthread_mutex_t*)ctx->refcount_lock);
+#endif
+    ctx->refcount++;
+#ifdef _WIN32
+    LeaveCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
+#else
+    pthread_mutex_unlock((pthread_mutex_t*)ctx->refcount_lock);
+#endif
+}
+
+/**
+ * @brief Atomically decrements the reference count and frees on zero.
+ *
+ * Drops one owning reference. When the final reference is released the context's
+ * subsystems are cleaned up and the structure is freed.
+ *
+ * @param ctx The context to release. No-op if NULL or uninitialized.
+ *
+ * @return Nothing.
+ */
+void dogecoin_context_release(dogecoin_context* ctx)
+{
+    dogecoin_bool should_free = false;
+    if (!ctx) return;
+    if (!ctx->refcount_lock) return;
+#ifdef _WIN32
+    EnterCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
+#else
+    pthread_mutex_lock((pthread_mutex_t*)ctx->refcount_lock);
+#endif
+    if (ctx->refcount > 0) ctx->refcount--;
+    if (ctx->refcount == 0) should_free = true;
+#ifdef _WIN32
+    LeaveCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
+#else
+    pthread_mutex_unlock((pthread_mutex_t*)ctx->refcount_lock);
+#endif
+    if (!should_free) return;
+    dogecoin_context_cleanup(ctx);
+    dogecoin_free(ctx);
+}
+
+/**
+ * @brief Returns the chain parameters bound to a context.
+ *
+ * @param ctx The context to query. May be NULL.
+ *
+ * @return The chain parameters, or NULL if ctx is NULL.
+ */
+const dogecoin_chainparams* dogecoin_context_get_chainparams(const dogecoin_context* ctx)
+{
+    return ctx ? ctx->chain_params : NULL;
+}
+
+/**
+ * @brief Returns the per-context transaction sub-context.
+ *
+ * @param ctx The context to query. May be NULL.
+ *
+ * @return The transaction context, or NULL if ctx is NULL.
+ */
+struct dogecoin_transaction_context* dogecoin_context_get_transaction_context(dogecoin_context* ctx)
+{
+    return ctx ? ctx->tx_ctx : NULL;
+}
+
+/**
+ * @brief Returns the per-context eckey sub-context.
+ *
+ * @param ctx The context to query. May be NULL.
+ *
+ * @return The eckey context, or NULL if ctx is NULL.
+ */
+struct dogecoin_eckey_context* dogecoin_context_get_eckey_context(dogecoin_context* ctx)
+{
+    return ctx ? ctx->key_ctx : NULL;
+}
+
+/**
+ * @brief Returns the opaque per-context secp256k1 context.
+ *
+ * @param ctx The context to query. May be NULL.
+ *
+ * @return The secp256k1 context pointer, or NULL if ctx is NULL.
+ */
+void* dogecoin_context_get_ecc_context(dogecoin_context* ctx)
+{
+    return ctx ? ctx->ecc_ctx : NULL;
+}
+
+/**
+ * @brief Returns the opaque per-context fast RNG state.
+ *
+ * @param ctx The context to query. May be NULL.
+ *
+ * @return The RNG state pointer, or NULL if ctx is NULL.
+ */
+void* dogecoin_context_get_rng_state(dogecoin_context* ctx)
+{
+    return ctx ? ctx->rng_state : NULL;
+}
+
+/**
+ * @brief Records an error code and message on a context.
+ *
+ * Stores the supplied code and copies the message (truncated to fit) into the
+ * context's last-error buffer for later retrieval.
+ *
+ * @param ctx  The context to update. No-op if NULL.
+ * @param code The numeric error code to store.
+ * @param msg  The error message, or NULL to clear the message.
+ *
+ * @return Nothing.
+ */
+void dogecoin_context_set_error(dogecoin_context* ctx, int code, const char* msg)
+{
+    if (!ctx) return;
+    ctx->error_code = code;
+    if (!msg) {
+        ctx->last_error[0] = '\0';
+        return;
+    }
+    strncpy(ctx->last_error, msg, sizeof(ctx->last_error) - 1);
+    ctx->last_error[sizeof(ctx->last_error) - 1] = '\0';
+}
+
+/**
+ * @brief Returns the last error code recorded on a context.
+ *
+ * @param ctx The context to query. May be NULL.
+ *
+ * @return The stored error code, or 0 if ctx is NULL.
+ */
+int dogecoin_context_get_error_code(const dogecoin_context* ctx)
+{
+    return ctx ? ctx->error_code : 0;
+}
+
+/**
+ * @brief Returns the last error message recorded on a context.
+ *
+ * @param ctx The context to query. May be NULL.
+ *
+ * @return The stored error message, or an empty string if ctx is NULL.
+ */
+const char* dogecoin_context_get_error(const dogecoin_context* ctx)
+{
+    if (!ctx) return "";
+    return ctx->last_error;
+}
+
+/**
+ * @brief Generates a private/public keypair using a context's chain.
+ *
+ * Produces a WIF-encoded private key and matching P2PKH address for the chain
+ * selected by the context. When wif or addr is NULL the required buffer sizes
+ * are returned via wif_size/addr_size without generating output. On buffer
+ * overflow the required sizes are written and an error is recorded on the
+ * context.
+ *
+ * @param ctx       The context selecting the chain. Receives error state on failure.
+ * @param wif       Destination buffer for the WIF key, or NULL to query the size.
+ * @param wif_size  In/out: capacity of wif on input, bytes needed on output.
+ * @param addr      Destination buffer for the address, or NULL to query the size.
+ * @param addr_size In/out: capacity of addr on input, bytes needed on output.
+ *
+ * @return true on success, false on invalid arguments, generation failure, or
+ *         insufficient buffer capacity.
+ */
+int dogecoin_generate_keypair_ex(dogecoin_context* ctx, char* wif, size_t* wif_size, char* addr, size_t* addr_size)
+{
+    if (!ctx || !wif_size || !addr_size) {
+        dogecoin_context_set_error(ctx, -1, "invalid arguments");
+        return false;
+    }
+
+    const dogecoin_bool is_testnet = (ctx->chain_params != &dogecoin_chainparams_main);
+    char tmp_wif[PRIVKEYWIFLEN] = {0};
+    char tmp_addr[P2PKHLEN] = {0};
+    if (!generatePrivPubKeypair(tmp_wif, tmp_addr, is_testnet)) {
+        dogecoin_context_set_error(ctx, -2, "key generation failed");
+        return false;
+    }
+
+    size_t wif_need = strlen(tmp_wif) + 1;
+    size_t addr_need = strlen(tmp_addr) + 1;
+    dogecoin_context_zero_error(ctx);
+    if (!wif || !addr) {
+        *wif_size = wif_need;
+        *addr_size = addr_need;
+        return true;
+    }
+    if (*wif_size < wif_need || *addr_size < addr_need) {
+        *wif_size = wif_need;
+        *addr_size = addr_need;
+        dogecoin_context_set_error(ctx, -3, "output buffer too small");
+        return false;
+    }
+
+    memcpy(wif, tmp_wif, wif_need);
+    memcpy(addr, tmp_addr, addr_need);
+    *wif_size = wif_need;
+    *addr_size = addr_need;
+    return true;
+}
+
+/* Short-form alias API: dogecoin_ctx_*
+ * These are thin aliases over dogecoin_context_* that match the API surface
+ * documented in doc/thread_safety.md. dogecoin_ctx_new_ts() additionally
+ * marks the context as thread-safe so dependent subsystems can opt into
+ * per-object locking when wired through the context. */
+
+/**
+ * @brief Creates a thread-compatible context (short-form alias).
+ *
+ * Equivalent to dogecoin_context_new() and leaves the context untagged so
+ * subsystems use their default (non-_ts) single-owner behavior.
+ *
+ * @param testnet    Selects testnet chain parameters when true, mainnet otherwise.
+ * @param enable_net Records whether networking is intended for this context.
+ *
+ * @return A pointer to the new context, or NULL on failure.
+ */
+dogecoin_ctx* dogecoin_ctx_new(dogecoin_bool testnet, dogecoin_bool enable_net)
+{
+    dogecoin_ctx* ctx = dogecoin_context_new(testnet, enable_net);
+    if (ctx) ctx->thread_safe = 0;
+    return ctx;
+}
+
+/**
+ * @brief Creates a thread-safe-tagged context (short-form alias).
+ *
+ * Equivalent to dogecoin_context_new() but marks the context as thread-safe so
+ * dependent subsystems select per-object locking via dogecoin_ctx_is_thread_safe().
+ *
+ * @param testnet    Selects testnet chain parameters when true, mainnet otherwise.
+ * @param enable_net Records whether networking is intended for this context.
+ *
+ * @return A pointer to the new thread-safe context, or NULL on failure.
+ */
+dogecoin_ctx* dogecoin_ctx_new_ts(dogecoin_bool testnet, dogecoin_bool enable_net)
+{
+    dogecoin_ctx* ctx = dogecoin_context_new(testnet, enable_net);
+    if (ctx) ctx->thread_safe = 1;
+    return ctx;
+}
+
+/**
+ * @brief Retains a context reference (short-form alias).
+ *
+ * @param ctx The context to retain. No-op if NULL.
+ *
+ * @return Nothing.
+ */
+void dogecoin_ctx_acquire(dogecoin_ctx* ctx)
+{
+    dogecoin_context_acquire(ctx);
+}
+
+/**
+ * @brief Releases a context reference (short-form alias).
+ *
+ * @param ctx The context to release. No-op if NULL.
+ *
+ * @return Nothing.
+ */
+void dogecoin_ctx_release(dogecoin_ctx* ctx)
+{
+    dogecoin_context_release(ctx);
+}
+
+/**
+ * @brief Reports whether a context was tagged thread-safe.
+ *
+ * @param ctx The context to query. May be NULL.
+ *
+ * @return Nonzero if the context was created via dogecoin_ctx_new_ts(), 0 otherwise.
+ */
+int dogecoin_ctx_is_thread_safe(const dogecoin_ctx* ctx)
+{
+    return ctx ? ctx->thread_safe : 0;
+}

--- a/src/context.c
+++ b/src/context.c
@@ -126,6 +126,7 @@ dogecoin_context* dogecoin_context_new(dogecoin_bool testnet, dogecoin_bool enab
     ctx->refcount = 1;
     ctx->refcount_lock = dogecoin_calloc(1, dogecoin_refcount_lock_size());
     if (!ctx->refcount_lock) {
+        fprintf(stderr, "CTXNEW FAIL: refcount_lock alloc\n");
         dogecoin_free(ctx);
         return NULL;
     }
@@ -133,6 +134,7 @@ dogecoin_context* dogecoin_context_new(dogecoin_bool testnet, dogecoin_bool enab
     InitializeCriticalSection((CRITICAL_SECTION*)ctx->refcount_lock);
 #else
     if (pthread_mutex_init((pthread_mutex_t*)ctx->refcount_lock, NULL) != 0) {
+        fprintf(stderr, "CTXNEW FAIL: pthread_mutex_init\n");
         dogecoin_free(ctx->refcount_lock);
         ctx->refcount_lock = NULL;
         dogecoin_free(ctx);
@@ -141,6 +143,7 @@ dogecoin_context* dogecoin_context_new(dogecoin_bool testnet, dogecoin_bool enab
 #endif
     ctx->ecc_ctx = secp256k1_context_create(SECP256K1_CONTEXT_SIGN | SECP256K1_CONTEXT_VERIFY);
     if (!ctx->ecc_ctx) {
+        fprintf(stderr, "CTXNEW FAIL: secp256k1_context_create\n");
         dogecoin_context_cleanup(ctx);
         dogecoin_free(ctx);
         return NULL;
@@ -151,6 +154,7 @@ dogecoin_context* dogecoin_context_new(dogecoin_bool testnet, dogecoin_bool enab
     } randomization_seed;
     if (!dogecoin_random_bytes(randomization_seed.bytes, sizeof(randomization_seed.bytes), 0) ||
         !secp256k1_context_randomize((secp256k1_context*)ctx->ecc_ctx, randomization_seed.bytes)) {
+        fprintf(stderr, "CTXNEW FAIL: random_bytes/randomize\n");
         dogecoin_mem_zero(randomization_seed.bytes, sizeof(randomization_seed.bytes));
         dogecoin_context_cleanup(ctx);
         dogecoin_free(ctx);
@@ -162,6 +166,8 @@ dogecoin_context* dogecoin_context_new(dogecoin_bool testnet, dogecoin_bool enab
     ctx->tx_ctx = dogecoin_transaction_context_new();
     ctx->key_ctx = dogecoin_eckey_context_new();
     if (!ctx->rng_state || !ctx->tx_ctx || !ctx->key_ctx) {
+        fprintf(stderr, "CTXNEW FAIL: rng=%p tx=%p key=%p\n",
+                (void*)ctx->rng_state, (void*)ctx->tx_ctx, (void*)ctx->key_ctx);
         dogecoin_context_cleanup(ctx);
         dogecoin_free(ctx);
         return NULL;

--- a/src/ecc.c
+++ b/src/ecc.c
@@ -9,7 +9,7 @@
 #include "secp256k1/include/secp256k1.h"
 #include "secp256k1/include/secp256k1_recovery.h"
 
-static secp256k1_context* secp256k1_ctx = NULL;
+static DOGECOIN_THREAD_LOCAL secp256k1_context* secp256k1_ctx = NULL;
 
 dogecoin_bool dogecoin_ecc_start(void)
 {

--- a/src/eckey.c
+++ b/src/eckey.c
@@ -33,6 +33,25 @@
 #include <dogecoin/mem.h>
 #include <dogecoin/utils.h>
 
+static dogecoin_eckey_context* default_eckey_context(void) {
+    static DOGECOIN_THREAD_LOCAL dogecoin_eckey_context default_ctx = {0};
+    return &default_ctx;
+}
+
+dogecoin_eckey_context* dogecoin_eckey_context_new(void) {
+    return (dogecoin_eckey_context*)dogecoin_calloc(1, sizeof(dogecoin_eckey_context));
+}
+
+void dogecoin_eckey_context_free(dogecoin_eckey_context* ctx) {
+    if (!ctx) return;
+    eckey* current;
+    eckey* tmp;
+    HASH_ITER(hh, ctx->keys, current, tmp) {
+        remove_eckey_ts(ctx, current);
+    }
+    dogecoin_free(ctx);
+}
+
 /**
  * @brief This function instantiates a new working eckey,
  * but does not add it to the hash table.
@@ -40,6 +59,11 @@
  * @return A pointer to the new working eckey.
  */
 eckey* new_eckey(dogecoin_bool is_testnet) {
+    return new_eckey_ts(default_eckey_context(), is_testnet);
+}
+
+eckey* new_eckey_ts(dogecoin_eckey_context* ctx, dogecoin_bool is_testnet) {
+    if (!ctx) return NULL;
     eckey* key = (struct eckey*)dogecoin_calloc(1, sizeof *key);
     dogecoin_privkey_init(&key->private_key);
     assert(dogecoin_privkey_is_valid(&key->private_key) == 0);
@@ -54,9 +78,9 @@ eckey* new_eckey(dogecoin_bool is_testnet) {
     pkeybase58c[0] = chain->b58prefix_secret_address;
     pkeybase58c[33] = 1; /* always use compressed keys */
     memcpy_safe(&pkeybase58c[1], &key->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) return false;
-    if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) return false;
-    key->idx = HASH_COUNT(keys) + 1;
+    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) return NULL;
+    if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) return NULL;
+    key->idx = HASH_COUNT(ctx->keys) + 1;
     return key;
 }
 
@@ -67,10 +91,15 @@ eckey* new_eckey(dogecoin_bool is_testnet) {
  * @return A pointer to the new working eckey.
  */
 eckey* new_eckey_from_privkey(char* private_key) {
+    return new_eckey_from_privkey_ts(default_eckey_context(), private_key);
+}
+
+eckey* new_eckey_from_privkey_ts(dogecoin_eckey_context* ctx, char* private_key) {
+    if (!ctx || !private_key) return NULL;
     eckey* key = (struct eckey*)dogecoin_calloc(1, sizeof *key);
     dogecoin_privkey_init(&key->private_key);
     const dogecoin_chainparams* chain = chain_from_b58_prefix(private_key);
-    if (!dogecoin_privkey_decode_wif(private_key, chain, &key->private_key)) return false;
+    if (!dogecoin_privkey_decode_wif(private_key, chain, &key->private_key)) return NULL;
     assert(dogecoin_privkey_is_valid(&key->private_key)==1);
     dogecoin_pubkey_init(&key->public_key);
     dogecoin_pubkey_from_key(&key->private_key, &key->public_key);
@@ -80,9 +109,9 @@ eckey* new_eckey_from_privkey(char* private_key) {
     pkeybase58c[0] = chain->b58prefix_secret_address;
     pkeybase58c[33] = 1; /* always use compressed keys */
     memcpy_safe(&pkeybase58c[1], &key->private_key, DOGECOIN_ECKEY_PKEY_LENGTH);
-    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) return false;
-    if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) return false;
-    key->idx = HASH_COUNT(keys) + 1;
+    if (dogecoin_base58_encode_check(pkeybase58c, sizeof(pkeybase58c), key->private_key_wif, sizeof(key->private_key_wif)) == 0) return NULL;
+    if (!dogecoin_pubkey_getaddr_p2pkh(&key->public_key, chain, (char*)&key->address)) return NULL;
+    key->idx = HASH_COUNT(ctx->keys) + 1;
     return key;
 }
 
@@ -95,12 +124,17 @@ eckey* new_eckey_from_privkey(char* private_key) {
  * @return Nothing.
  */
 void add_eckey(eckey *key) {
+    add_eckey_ts(default_eckey_context(), key);
+}
+
+void add_eckey_ts(dogecoin_eckey_context* ctx, eckey *key) {
+    if (!ctx || !key) return;
     eckey* key_old;
-    HASH_FIND_INT(keys, &key->idx, key_old);
+    HASH_FIND_INT(ctx->keys, &key->idx, key_old);
     if (key_old == NULL) {
-        HASH_ADD_INT(keys, idx, key);
+        HASH_ADD_INT(ctx->keys, idx, key);
     } else {
-        HASH_REPLACE_INT(keys, idx, key, key_old);
+        HASH_REPLACE_INT(ctx->keys, idx, key, key_old);
     }
     dogecoin_free(key_old);
 }
@@ -115,8 +149,13 @@ void add_eckey(eckey *key) {
  * the provided index.
  */
 eckey* find_eckey(int idx) {
+    return find_eckey_ts(default_eckey_context(), idx);
+}
+
+eckey* find_eckey_ts(dogecoin_eckey_context* ctx, int idx) {
+    if (!ctx) return NULL;
     eckey* key;
-    HASH_FIND_INT(keys, &idx, key);
+    HASH_FIND_INT(ctx->keys, &idx, key);
     return key;
 }
 
@@ -129,7 +168,12 @@ eckey* find_eckey(int idx) {
  * @return Nothing.
  */
 void remove_eckey(eckey* key) {
-    HASH_DEL(keys, key); /* delete it (keys advances to next) */
+    remove_eckey_ts(default_eckey_context(), key);
+}
+
+void remove_eckey_ts(dogecoin_eckey_context* ctx, eckey* key) {
+    if (!ctx || !key) return;
+    HASH_DEL(ctx->keys, key); /* delete it (keys advances to next) */
     dogecoin_privkey_cleanse(&key->private_key);
     dogecoin_pubkey_cleanse(&key->public_key);
     dogecoin_key_free(key);
@@ -158,8 +202,14 @@ void dogecoin_key_free(eckey* eckey)
  * @return The index of the new key.
  */
 int start_key(dogecoin_bool is_testnet) {
-    eckey* key = new_eckey(is_testnet);
+    return start_key_ts(default_eckey_context(), is_testnet);
+}
+
+int start_key_ts(dogecoin_eckey_context* ctx, dogecoin_bool is_testnet) {
+    if (!ctx) return -1;
+    eckey* key = new_eckey_ts(ctx, is_testnet);
+    if (!key) return -1;
     int index = key->idx;
-    add_eckey(key);
+    add_eckey_ts(ctx, key);
     return index;
 }

--- a/src/mem.c
+++ b/src/mem.c
@@ -37,7 +37,7 @@ void* dogecoin_realloc_internal(void* ptr, size_t size);
 void dogecoin_free_internal(void* ptr);
 
 static const dogecoin_mem_mapper default_mem_mapper = {dogecoin_malloc_internal, dogecoin_calloc_internal, dogecoin_realloc_internal, dogecoin_free_internal};
-static dogecoin_mem_mapper current_mem_mapper = {dogecoin_malloc_internal, dogecoin_calloc_internal, dogecoin_realloc_internal, dogecoin_free_internal};
+static DOGECOIN_THREAD_LOCAL dogecoin_mem_mapper current_mem_mapper = {dogecoin_malloc_internal, dogecoin_calloc_internal, dogecoin_realloc_internal, dogecoin_free_internal};
 
 
 /**

--- a/src/net.c
+++ b/src/net.c
@@ -660,8 +660,9 @@ void dogecoin_node_connection_state_changed(dogecoin_node* node)
         if ((node->state & NODE_CONNECTED) == NODE_CONNECTED || (node->state & NODE_CONNECTING) == NODE_CONNECTING) {
             dogecoin_node_disconnect(node);
         }
-    } else
+    } else if ((node->state & NODE_CONNECTED) == NODE_CONNECTED && node->event_bev) {
         dogecoin_node_send_version(node);
+    }
 }
 
 /**
@@ -674,7 +675,7 @@ void dogecoin_node_connection_state_changed(dogecoin_node* node)
  */
 void dogecoin_node_send(dogecoin_node* node, cstring* data)
 {
-    if ((node->state & NODE_CONNECTED) != NODE_CONNECTED)
+    if ((node->state & NODE_CONNECTED) != NODE_CONNECTED || !node->event_bev)
         return;
 
     bufferevent_write(node->event_bev, data->str, data->len);

--- a/src/random.c
+++ b/src/random.c
@@ -112,7 +112,7 @@ void dogecoin_random_init_internal(void);
 dogecoin_bool dogecoin_random_bytes_internal(uint8_t* buf, uint32_t len, const uint8_t update_seed);
 
 static const dogecoin_rnd_mapper default_rnd_mapper = { dogecoin_random_init_internal, dogecoin_random_bytes_internal };
-static dogecoin_rnd_mapper current_rnd_mapper = { dogecoin_random_init_internal, dogecoin_random_bytes_internal };
+static DOGECOIN_THREAD_LOCAL dogecoin_rnd_mapper current_rnd_mapper = { dogecoin_random_init_internal, dogecoin_random_bytes_internal };
 
 void dogecoin_rnd_set_mapper_default()
     {
@@ -149,7 +149,7 @@ dogecoin_bool dogecoin_random_bytes_internal(uint8_t* buf, uint32_t len, const u
     }
 #else
 /* Define a function pointer for random */
-int (*rng_ptr) (void*, size_t) = NULL;
+DOGECOIN_THREAD_LOCAL int (*rng_ptr) (void*, size_t) = NULL;
 void set_rng(int (*ptr)(void *, size_t))
     {
     rng_ptr = ptr;

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -35,7 +35,31 @@
 #include <dogecoin/transaction.h>
 #include <dogecoin/tx.h>
 #include <dogecoin/utils.h>
+#include <dogecoin/wallet.h>
 #include <dogecoin/vector.h>
+
+static dogecoin_transaction_context* default_transaction_context(void) {
+    static DOGECOIN_THREAD_LOCAL dogecoin_transaction_context default_ctx = {0};
+    return &default_ctx;
+}
+
+/* internal helpers for the thread-safe index API (defined below) */
+static int add_address_output_ts(working_transaction* tx, const dogecoin_chainparams* chain, int64_t koinu, const char* address);
+static int make_change_ts(dogecoin_transaction_context* ctx, int txindex, char* public_key, uint64_t subtractedfee, uint64_t amount);
+
+dogecoin_transaction_context* dogecoin_transaction_context_default(void) {
+    return default_transaction_context();
+}
+
+dogecoin_transaction_context* dogecoin_transaction_context_new(void) {
+    return (dogecoin_transaction_context*)dogecoin_calloc(1, sizeof(dogecoin_transaction_context));
+}
+
+void dogecoin_transaction_context_free(dogecoin_transaction_context* ctx) {
+    if (!ctx) return;
+    remove_all_ts(ctx);
+    dogecoin_free(ctx);
+}
 
 /**
  * @brief This function instantiates a new working transaction,
@@ -44,9 +68,31 @@
  * @return A pointer to the new working transaction.
  */
 working_transaction* new_transaction() {
+    dogecoin_transaction_context* ctx = default_transaction_context();
+    if (!ctx) return NULL;
     working_transaction* working_tx = (struct working_transaction*)dogecoin_calloc(1, sizeof *working_tx);
+    if (!working_tx) return NULL;
     working_tx->transaction = dogecoin_tx_new();
-    working_tx->idx = HASH_COUNT(transactions) + 1;
+    if (!working_tx->transaction) {
+        dogecoin_free(working_tx);
+        return NULL;
+    }
+    working_tx->idx = HASH_COUNT(ctx->transactions) + 1;
+    return working_tx;
+}
+
+working_transaction* new_transaction_ts(dogecoin_transaction_context* ctx) {
+    if (!ctx) return NULL;
+    working_transaction* working_tx = (struct working_transaction*)dogecoin_calloc(1, sizeof *working_tx);
+    if (!working_tx) return NULL;
+    /* Thread-safe registry entries carry a mutex-bearing transaction so the
+       _ts CLI builds operate on per-transaction-locked objects. */
+    working_tx->transaction = dogecoin_tx_new_ts();
+    if (!working_tx->transaction) {
+        dogecoin_free(working_tx);
+        return NULL;
+    }
+    working_tx->idx = HASH_COUNT(ctx->transactions) + 1;
     return working_tx;
 }
 
@@ -59,12 +105,17 @@ working_transaction* new_transaction() {
  * @return Nothing.
  */
 void add_transaction(working_transaction *working_tx) {
+    add_transaction_ts(default_transaction_context(), working_tx);
+}
+
+void add_transaction_ts(dogecoin_transaction_context* ctx, working_transaction *working_tx) {
+    if (!ctx || !working_tx) return;
     working_transaction *tx;
-    HASH_FIND_INT(transactions, &working_tx->idx, tx);
+    HASH_FIND_INT(ctx->transactions, &working_tx->idx, tx);
     if (tx == NULL) {
-        HASH_ADD_INT(transactions, idx, working_tx);
+        HASH_ADD_INT(ctx->transactions, idx, working_tx);
     } else {
-        HASH_REPLACE_INT(transactions, idx, working_tx, tx);
+        HASH_REPLACE_INT(ctx->transactions, idx, working_tx, tx);
     }
     dogecoin_free(tx);
 }
@@ -79,8 +130,13 @@ void add_transaction(working_transaction *working_tx) {
  * the provided index.
  */
 working_transaction* find_transaction(int idx) {
+    return find_transaction_ts(default_transaction_context(), idx);
+}
+
+working_transaction* find_transaction_ts(dogecoin_transaction_context* ctx, int idx) {
+    if (!ctx) return NULL;
     working_transaction *working_tx;
-    HASH_FIND_INT(transactions, &idx, working_tx);
+    HASH_FIND_INT(ctx->transactions, &idx, working_tx);
     return working_tx;
 }
 
@@ -93,7 +149,12 @@ working_transaction* find_transaction(int idx) {
  * @return Nothing.
  */
 void remove_transaction(working_transaction *working_tx) {
-    HASH_DEL(transactions, working_tx); /* delete it (transactions advances to next) */
+    remove_transaction_ts(default_transaction_context(), working_tx);
+}
+
+void remove_transaction_ts(dogecoin_transaction_context* ctx, working_transaction *working_tx) {
+    if (!ctx || !working_tx) return;
+    HASH_DEL(ctx->transactions, working_tx); /* delete it (transactions advances to next) */
     dogecoin_tx_free(working_tx->transaction);
     dogecoin_free(working_tx);
 }
@@ -105,11 +166,16 @@ void remove_transaction(working_transaction *working_tx) {
  * @return Nothing.
  */
 void remove_all() {
+    remove_all_ts(default_transaction_context());
+}
+
+void remove_all_ts(dogecoin_transaction_context* ctx) {
+    if (!ctx) return;
     struct working_transaction *current_tx;
     struct working_transaction *tmp;
 
-    HASH_ITER(hh, transactions, current_tx, tmp) {
-        remove_transaction(current_tx);
+    HASH_ITER(hh, ctx->transactions, current_tx, tmp) {
+        remove_transaction_ts(ctx, current_tx);
     }
 }
 
@@ -122,8 +188,9 @@ void remove_all() {
 void print_transactions()
 {
     struct working_transaction *s;
+    working_transaction* root = default_transaction_context()->transactions;
 
-    for (s = transactions; s != NULL; s = (struct working_transaction*)(s->hh.next)) {
+    for (s = root; s != NULL; s = (struct working_transaction*)(s->hh.next)) {
         printf("\nworking transaction id: %d\nraw transaction (hexadecimal): %s\n", s->idx, get_raw_transaction(s->idx));
     }
 }
@@ -135,8 +202,119 @@ void print_transactions()
  * @return Nothing.
  */
 void count_transactions() {
-    int temp = HASH_COUNT(transactions);
+    int temp = get_transaction_count();
     printf("there are %d transactions\n", temp);
+}
+
+int get_transaction_count(void) {
+    return get_transaction_count_ts(default_transaction_context());
+}
+
+int get_transaction_count_ts(dogecoin_transaction_context* ctx) {
+    if (!ctx) return 0;
+    return HASH_COUNT(ctx->transactions);
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+dogecoin_tx* dogecoin_tx_new_ts(void)
+{
+    dogecoin_tx* tx = dogecoin_tx_new();
+    if (!tx) return NULL;
+    if (!dogecoin_mutex_init(&tx->lock)) {
+        dogecoin_tx_free(tx);
+        return NULL;
+    }
+    tx->thread_safe = true;
+    return tx;
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+void dogecoin_tx_free_ts(dogecoin_tx* tx)
+{
+    dogecoin_tx_free(tx);
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+int dogecoin_tx_add_input_ts(dogecoin_tx* tx, const dogecoin_tx_in* tx_in)
+{
+    if (!tx || !tx_in || !tx->vin) return false;
+    if (tx->thread_safe) dogecoin_mutex_lock(&tx->lock);
+    dogecoin_tx_in* tx_in_new = dogecoin_tx_in_new();
+    if (!tx_in_new) {
+        if (tx->thread_safe) dogecoin_mutex_unlock(&tx->lock);
+        return false;
+    }
+    dogecoin_tx_in_copy(tx_in_new, tx_in);
+    vector_add(tx->vin, tx_in_new);
+    if (tx->thread_safe) dogecoin_mutex_unlock(&tx->lock);
+    return true;
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+int dogecoin_tx_add_output_ts(dogecoin_tx* tx, const dogecoin_tx_out* tx_out)
+{
+    if (!tx || !tx_out || !tx->vout) return false;
+    if (tx->thread_safe) dogecoin_mutex_lock(&tx->lock);
+    dogecoin_tx_out* tx_out_new = dogecoin_tx_out_new();
+    if (!tx_out_new) {
+        if (tx->thread_safe) dogecoin_mutex_unlock(&tx->lock);
+        return false;
+    }
+    dogecoin_tx_out_copy(tx_out_new, tx_out);
+    vector_add(tx->vout, tx_out_new);
+    if (tx->thread_safe) dogecoin_mutex_unlock(&tx->lock);
+    return true;
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+int dogecoin_tx_sign_ts(dogecoin_tx* tx, dogecoin_wallet* wallet, const char* passphrase)
+{
+    /* Reserved for future encrypted-wallet integration. */
+    (void)passphrase;
+    if (!tx || !wallet || !wallet->masterkey || !dogecoin_hdnode_has_privkey(wallet->masterkey)) return false;
+    /* Lock-order contract: always acquire tx->lock before wallet->lock. */
+    if (tx->thread_safe) dogecoin_mutex_lock(&tx->lock);
+    if (wallet->thread_safe) dogecoin_mutex_lock(&wallet->lock);
+
+    dogecoin_key key;
+    dogecoin_privkey_init(&key);
+    memcpy(key.privkey, wallet->masterkey->private_key, sizeof(key.privkey));
+
+    size_t i;
+    int ok = true;
+    for (i = 0; i < tx->vin->len; i++) {
+        dogecoin_tx_in* txin = vector_idx(tx->vin, i);
+        if (!txin || !txin->script_sig || txin->script_sig->len == 0) continue;
+        uint8_t sigcompact[64] = {0};
+        uint8_t sigder[75] = {0};
+        size_t sigder_len = sizeof(sigder);
+        enum dogecoin_tx_sign_result res = dogecoin_tx_sign_input(tx, txin->script_sig, &key, i, 1, sigcompact, sigder, &sigder_len);
+        if (res != DOGECOIN_SIGN_OK && res != DOGECOIN_SIGN_NO_KEY_MATCH) {
+            ok = false;
+            break;
+        }
+    }
+
+    dogecoin_privkey_cleanse(&key);
+    if (wallet->thread_safe) dogecoin_mutex_unlock(&wallet->lock);
+    if (tx->thread_safe) dogecoin_mutex_unlock(&tx->lock);
+    return ok;
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+int dogecoin_tx_finalize_ts(dogecoin_tx* tx)
+{
+    if (!tx) return false;
+    if (tx->thread_safe) dogecoin_mutex_lock(&tx->lock);
+    /* Finalization currently performs a deterministic serialization+hash pass
+     * as an integrity check; no additional state is persisted yet. */
+    cstring* tmp = cstr_new_sz(256);
+    dogecoin_tx_serialize(tmp, tx);
+    uint256_t hash;
+    dogecoin_tx_hash(tx, hash);
+    cstr_free(tmp, true);
+    if (tx->thread_safe) dogecoin_mutex_unlock(&tx->lock);
+    return true;
 }
 
 /**
@@ -229,9 +407,15 @@ const char *get_private_key(const char *prompt_key)
  * @return The index of the new transaction.
  */
 int start_transaction() {
-    working_transaction* working_tx = new_transaction();
+    return start_transaction_ts(default_transaction_context());
+}
+
+int start_transaction_ts(dogecoin_transaction_context* ctx) {
+    if (!ctx) return -1;
+    working_transaction* working_tx = new_transaction_ts(ctx);
+    if (!working_tx) return -1;
     int index = working_tx->idx;
-    add_transaction(working_tx);
+    add_transaction_ts(ctx, working_tx);
     return index;
 }
 
@@ -246,8 +430,12 @@ int start_transaction() {
  * @return 1 if the transaction was saved successfully, 0 otherwise.
  */
 int save_raw_transaction(int txindex, const char* hexadecimal_transaction) {
+    return save_raw_transaction_ts(default_transaction_context(), txindex, hexadecimal_transaction);
+}
+
+int save_raw_transaction_ts(dogecoin_transaction_context* ctx, int txindex, const char* hexadecimal_transaction) {
     debug_print("raw_hexadecimal_transaction: %s\n", hexadecimal_transaction);
-    if (!hexadecimal_transaction) {
+    if (!ctx || !hexadecimal_transaction) {
         printf("invalid tx hex\n");
         return false;
     }
@@ -272,8 +460,17 @@ int save_raw_transaction(int txindex, const char* hexadecimal_transaction) {
         return false;
     }
     // free byte array
-    working_transaction* tx_raw = find_transaction(txindex);
+    working_transaction* tx_raw = find_transaction_ts(ctx, txindex);
+    if (!tx_raw) {
+        dogecoin_tx_free(txtmp);
+        dogecoin_free(data_bin);
+        return false;
+    }
+    // hold the per-object mutex while overwriting the working transaction
+    dogecoin_bool locked = tx_raw->transaction->thread_safe;
+    if (locked) dogecoin_mutex_lock(&tx_raw->transaction->lock);
     dogecoin_tx_copy(tx_raw->transaction, txtmp);
+    if (locked) dogecoin_mutex_unlock(&tx_raw->transaction->lock);
     dogecoin_tx_free(txtmp);
     dogecoin_free(data_bin);
     return true;
@@ -290,8 +487,13 @@ int save_raw_transaction(int txindex, const char* hexadecimal_transaction) {
  * @return 1 if the transaction input was added successfully, 0 otherwise.
  */
 int add_utxo(int txindex, char* hex_utxo_txid, int vout) {
+    return add_utxo_ts(default_transaction_context(), txindex, hex_utxo_txid, vout);
+}
+
+int add_utxo_ts(dogecoin_transaction_context* ctx, int txindex, char* hex_utxo_txid, int vout) {
+    if (!ctx) return false;
     // find working transaction by index and pass to funciton local variable to manipulate:
-    working_transaction* tx = find_transaction(txindex);
+    working_transaction* tx = find_transaction_ts(ctx, txindex);
 
     // guard against null pointer exceptions
     if (tx == NULL) return false;
@@ -312,13 +514,16 @@ int add_utxo(int txindex, char* hex_utxo_txid, int vout) {
     // set index of utxo we want to spend
     tx_in->prevout.n = vout;
 
-    // add to working tx object
-    vector_add(tx->transaction->vin, tx_in);
+    // route the input through the thread-safe primitive, which copies tx_in
+    // into the working transaction under its per-object mutex when present:
+    int added = dogecoin_tx_add_input_ts(tx->transaction, tx_in);
 
-    // free tx_in struct since it has been added to our working tx
+    // dogecoin_tx_add_input_ts copies the input, so free our local template:
+    dogecoin_tx_in_free(tx_in);
+
     // ensure the length of our working tx inputs length has incremented by 1
     // which will return true if successful:
-    return flag + 1 == tx->transaction->vin->len;
+    return added && (flag + 1 == tx->transaction->vin->len);
 }
 
 /**
@@ -333,8 +538,46 @@ int add_utxo(int txindex, char* hex_utxo_txid, int vout) {
  * @return 1 if the transaction input was added successfully, 0 otherwise.
  */
 int add_output(int txindex, char* destinationaddress, char* amount) {
+    return add_output_ts(default_transaction_context(), txindex, destinationaddress, amount);
+}
+
+/**
+ * @brief Internal helper that appends an address output to a working
+ * transaction by routing it through the thread-safe dogecoin_tx_add_output_ts
+ * primitive. The output script is built with the existing
+ * dogecoin_tx_add_address_out logic into a throwaway transaction, then each
+ * resulting output is copied into the working transaction under its per-object
+ * mutex (when present).
+ *
+ * @return 1 if at least one output was added, 0 otherwise.
+ */
+static int add_address_output_ts(working_transaction* tx, const dogecoin_chainparams* chain, int64_t koinu, const char* address) {
+    if (!tx || !tx->transaction || !chain || !address) return false;
+
+    // build the output script(s) using the shared address-out logic in a scratch tx
+    dogecoin_tx* scratch = dogecoin_tx_new();
+    if (!scratch) return false;
+    if (!dogecoin_tx_add_address_out(scratch, chain, koinu, address)) {
+        dogecoin_tx_free(scratch);
+        return false;
+    }
+
+    int added = false;
+    size_t i;
+    for (i = 0; i < scratch->vout->len; i++) {
+        dogecoin_tx_out* tx_out = vector_idx(scratch->vout, i);
+        if (dogecoin_tx_add_output_ts(tx->transaction, tx_out)) {
+            added = true;
+        }
+    }
+    dogecoin_tx_free(scratch);
+    return added;
+}
+
+int add_output_ts(dogecoin_transaction_context* ctx, int txindex, char* destinationaddress, char* amount) {
+    if (!ctx) return false;
     // find working transaction by index and pass to funciton local variable to manipulate:
-    working_transaction* tx = find_transaction(txindex);
+    working_transaction* tx = find_transaction_ts(ctx, txindex);
     // guard against null pointer exceptions
     if (tx == NULL) {
         return false;
@@ -344,8 +587,8 @@ int add_output(int txindex, char* destinationaddress, char* amount) {
 
     uint64_t koinu = coins_to_koinu_str(amount);
     // calculate total minus fees
-    // pass in transaction obect, network paramters, amount of dogecoin to send to address and finally p2pkh address:
-    return dogecoin_tx_add_address_out(tx->transaction, chain, (int64_t)koinu, destinationaddress);
+    // route through the thread-safe output primitive:
+    return add_address_output_ts(tx, chain, (int64_t)koinu, destinationaddress);
 }
 
 /**
@@ -361,9 +604,14 @@ int add_output(int txindex, char* destinationaddress, char* amount) {
  * @return 1 if the additional output was created successfully, 0 otherwise.
  */
 static int make_change(int txindex, char* public_key, uint64_t subtractedfee, uint64_t amount) {
+    return make_change_ts(default_transaction_context(), txindex, public_key, subtractedfee, amount);
+}
+
+static int make_change_ts(dogecoin_transaction_context* ctx, int txindex, char* public_key, uint64_t subtractedfee, uint64_t amount) {
+    if (!ctx) return false;
     if (amount==subtractedfee) return false; // utxos already fully spent, no change needed
     // find working transaction by index and pass to funciton local variable to manipulate:
-    working_transaction* tx = find_transaction(txindex);
+    working_transaction* tx = find_transaction_ts(ctx, txindex);
 
     // guard against null pointer exceptions
     if (tx == NULL) return false;
@@ -374,7 +622,8 @@ static int make_change(int txindex, char* public_key, uint64_t subtractedfee, ui
     // calculate total minus fees
     uint64_t total_change_back = amount - subtractedfee;
 
-    return dogecoin_tx_add_address_out(tx->transaction, chain, total_change_back, public_key);
+    // route the change output through the thread-safe output primitive:
+    return add_address_output_ts(tx, chain, (int64_t)total_change_back, public_key);
 }
 
 /**
@@ -390,11 +639,16 @@ static int make_change(int txindex, char* public_key, uint64_t subtractedfee, ui
  * @return The hex of the finalized transaction.
  */
 char* finalize_transaction(int txindex, char* destinationaddress, char* subtractedfee, char* out_dogeamount_for_verification, char* changeaddress) {
+    return finalize_transaction_ts(default_transaction_context(), txindex, destinationaddress, subtractedfee, out_dogeamount_for_verification, changeaddress);
+}
+
+char* finalize_transaction_ts(dogecoin_transaction_context* ctx, int txindex, char* destinationaddress, char* subtractedfee, char* out_dogeamount_for_verification, char* changeaddress) {
+    if (!ctx) return NULL;
     // find working transaction by index and pass to funciton local variable to manipulate:
-    working_transaction* tx = find_transaction(txindex);
+    working_transaction* tx = find_transaction_ts(ctx, txindex);
 
     // guard against null pointer exceptions
-    if (tx == NULL) return false;
+    if (tx == NULL) return NULL;
 
     // determine intended network by checking address prefix:
     int is_testnet = chain_from_b58_prefix_bool(destinationaddress);
@@ -417,7 +671,7 @@ char* finalize_transaction(int txindex, char* destinationaddress, char* subtract
         p2pkh_count = dogecoin_tx_out_pubkey_hash_to_p2pkh_address(tx_out_tmp, (char *)p2pkh, is_testnet);
         if (i == length - 1 && changeaddress) {
             // manually make change and send back to our public key address
-            if (make_change(txindex, changeaddress, subtractedfee_koinu, out_koinu_for_verification - tx_out_total)) {
+            if (make_change_ts(ctx, txindex, changeaddress, subtractedfee_koinu, out_koinu_for_verification - tx_out_total)) {
                 p2pkh_count += 1;
                 tx_out_tmp = vector_idx(tx->transaction->vout, tx->transaction->vout->len - 1);
                 tx_out_total += tx_out_tmp->value;
@@ -428,11 +682,16 @@ char* finalize_transaction(int txindex, char* destinationaddress, char* subtract
 
     if (p2pkh_count < 1) {
         printf("p2pkh address not found from any output script hash!\n");
-        return false;
+        return NULL;
     }
 
+    if (tx_out_total != total) return NULL;
+
+    // run the thread-safe finalization integrity pass before serializing:
+    dogecoin_tx_finalize_ts(tx->transaction);
+
     // pass in transaction obect, network paramters, amount of dogecoin to send to address and finally p2pkh address:
-    return tx_out_total == total ? get_raw_transaction(txindex) : false;
+    return get_raw_transaction_ts(ctx, txindex);
 }
 
 /**
@@ -444,11 +703,20 @@ char* finalize_transaction(int txindex, char* destinationaddress, char* subtract
  * @return The hex representation of the transaction.
  */
 char* get_raw_transaction(int txindex) {
+    return get_raw_transaction_ts(default_transaction_context(), txindex);
+}
+
+char* get_raw_transaction_ts(dogecoin_transaction_context* ctx, int txindex) {
+    if (!ctx) return NULL;
     // find working transaction by index and pass to function local variable to manipulate:
-    working_transaction* tx = find_transaction(txindex);
+    working_transaction* tx = find_transaction_ts(ctx, txindex);
 
     // guard against null pointer exceptions
-    if (tx == NULL) return false;
+    if (tx == NULL) return NULL;
+
+    // serialize under the per-object mutex when present:
+    dogecoin_bool locked = tx->transaction->thread_safe;
+    if (locked) dogecoin_mutex_lock(&tx->transaction->lock);
 
     // new allocated cstring to store hexadeicmal buffer string:
     cstring* serialized_transaction = cstr_new_sz(1024);
@@ -459,6 +727,8 @@ char* get_raw_transaction(int txindex) {
     char* hexadecimal_buffer = utils_uint8_to_hex((unsigned char*)serialized_transaction->str, serialized_transaction->len);
 
     cstr_free(serialized_transaction, true);
+
+    if (locked) dogecoin_mutex_unlock(&tx->transaction->lock);
 
     return hexadecimal_buffer;
 }
@@ -472,10 +742,15 @@ char* get_raw_transaction(int txindex) {
  * @return Nothing.
  */
 void clear_transaction(int txindex) {
+    clear_transaction_ts(default_transaction_context(), txindex);
+}
+
+void clear_transaction_ts(dogecoin_transaction_context* ctx, int txindex) {
+    if (!ctx) return;
     // find working transaction by index and pass to funciton local variable to manipulate:
-    working_transaction* tx = find_transaction(txindex);
+    working_transaction* tx = find_transaction_ts(ctx, txindex);
     // remove from hashmap
-    remove_transaction(tx);
+    remove_transaction_ts(ctx, tx);
 }
 
 /**

--- a/src/tx.c
+++ b/src/tx.c
@@ -175,6 +175,10 @@ dogecoin_tx_out* dogecoin_tx_out_new()
  */
 void dogecoin_tx_free(dogecoin_tx* tx)
 {
+    if (!tx) return;
+    if (tx->lock.initialized) {
+        dogecoin_mutex_destroy(&tx->lock);
+    }
     if (tx->vin) {
         vector_free(tx->vin, true);
         tx->vin = NULL;
@@ -403,6 +407,8 @@ dogecoin_tx* dogecoin_tx_new()
     tx->vout = vector_new(8, dogecoin_tx_out_free_cb);
     tx->version = 1;
     tx->locktime = 0;
+    tx->thread_safe = false;
+    tx->lock.initialized = false;
     return tx;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -134,8 +134,8 @@ static void dogecoin_arm64_write_dit(unsigned dit_bit)
 }
 #endif
 
-static uint8_t buffer_hex_to_uint8[TO_UINT8_HEX_BUF_LEN];
-static char buffer_uint8_to_hex[TO_UINT8_HEX_BUF_LEN];
+static DOGECOIN_THREAD_LOCAL uint8_t buffer_hex_to_uint8[TO_UINT8_HEX_BUF_LEN];
+static DOGECOIN_THREAD_LOCAL char buffer_uint8_to_hex[TO_UINT8_HEX_BUF_LEN];
 
 
 /**

--- a/src/wallet.c
+++ b/src/wallet.c
@@ -47,6 +47,8 @@
 #include <dogecoin/wallet.h>
 #include <dogecoin/seal.h>
 
+const dogecoin_chainparams* dogecoin_context_get_chainparams(const struct dogecoin_context_* ctx);
+
 #define COINBASE_MATURITY 100
 
 uint8_t WALLET_DB_REC_TYPE_MASTERPUBKEY = 0;
@@ -57,6 +59,20 @@ uint8_t WALLET_DB_REC_TYPE_TX = 2;
 static const unsigned char file_hdr_magic[4] = {0xA8, 0xF0, 0x11, 0xC5}; /* header magic */
 static const unsigned char file_rec_magic[4] = {0xC8, 0xF2, 0x69, 0x1E}; /* record magic */
 static const uint32_t current_version = 1;
+
+static void wallet_lock(dogecoin_wallet* wallet)
+{
+    if (!wallet) return;
+    if (!wallet->thread_safe) return;
+    dogecoin_mutex_lock(&wallet->lock);
+}
+
+static void wallet_unlock(dogecoin_wallet* wallet)
+{
+    if (!wallet) return;
+    if (!wallet->thread_safe) return;
+    dogecoin_mutex_unlock(&wallet->lock);
+}
 
 /**
  * Prints an error message to the screen
@@ -380,6 +396,50 @@ dogecoin_wallet* dogecoin_wallet_new(const dogecoin_chainparams *params)
     wallet->wtxes_rbtree = 0;
     wallet->waddr_vector = vector_new(10, (void (*)(void *)) dogecoin_wallet_addr_free);
     wallet->waddr_rbtree = 0;
+    wallet->ctx = NULL;
+    wallet->thread_safe = false;
+    wallet->lock.initialized = false;
+    return wallet;
+}
+
+/* Promote an already-constructed wallet to thread-safe by attaching a context
+ * (whose refcount is retained) and initializing the per-object mutex. The
+ * wallet keeps the chain parameters it was created with, so this is safe to use
+ * for wallets whose chain (e.g. regtest) cannot be represented by a context.
+ * Idempotent; returns true on success. */
+int dogecoin_wallet_enable_thread_safe(dogecoin_wallet* wallet, dogecoin_ctx* ctx)
+{
+    if (!wallet) return false;
+    if (wallet->thread_safe) return true;
+    wallet->ctx = ctx;
+    if (wallet->ctx) {
+        dogecoin_ctx_acquire(wallet->ctx);
+    }
+    if (!dogecoin_mutex_init(&wallet->lock)) {
+        if (wallet->ctx) {
+            dogecoin_ctx_release(wallet->ctx);
+            wallet->ctx = NULL;
+        }
+        return false;
+    }
+    wallet->thread_safe = true;
+    return true;
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+dogecoin_wallet* dogecoin_wallet_new_ts(dogecoin_ctx* ctx)
+{
+    const dogecoin_chainparams* params = &dogecoin_chainparams_main;
+    if (ctx) {
+        const dogecoin_chainparams* from_ctx = dogecoin_context_get_chainparams((const struct dogecoin_context_*)ctx);
+        if (from_ctx) params = from_ctx;
+    }
+    dogecoin_wallet* wallet = dogecoin_wallet_new(params);
+    if (!wallet) return NULL;
+    if (!dogecoin_wallet_enable_thread_safe(wallet, ctx)) {
+        dogecoin_wallet_free(wallet);
+        return NULL;
+    }
     return wallet;
 }
 
@@ -564,6 +624,18 @@ dogecoin_wallet* dogecoin_wallet_init(const dogecoin_chainparams* chain, const c
     return wallet;
 }
 
+/* THREAD-SAFE variant of dogecoin_wallet_init - keeps the explicit chain and
+ * promotes the resulting wallet to thread-safe (attaches ctx, inits mutex). */
+dogecoin_wallet* dogecoin_wallet_init_ts(dogecoin_ctx* ctx, const dogecoin_chainparams* chain, const char* address, const char* name, const dogecoin_wallet_opts* opts) {
+    dogecoin_wallet* wallet = dogecoin_wallet_init(chain, address, name, opts);
+    if (!wallet) return NULL;
+    if (!dogecoin_wallet_enable_thread_safe(wallet, ctx)) {
+        dogecoin_wallet_free(wallet);
+        return NULL;
+    }
+    return wallet;
+}
+
 void print_utxos(dogecoin_wallet* wallet) {
     /* Creating a vector_t of addresses and storing them in the wallet. */
     vector_t* addrs = vector_new(1, free);
@@ -658,7 +730,41 @@ void dogecoin_wallet_free(dogecoin_wallet* wallet)
     dogecoin_btree_tdestroy(wallet->waddr_rbtree, NULL);
 
     remove_all_utxos();
+    if (wallet->lock.initialized) {
+        dogecoin_mutex_destroy(&wallet->lock);
+    }
+    if (wallet->ctx) {
+        dogecoin_ctx_release(wallet->ctx);
+        wallet->ctx = NULL;
+    }
     dogecoin_free(wallet);
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+dogecoin_wallet* dogecoin_wallet_load_ts(dogecoin_ctx* ctx, const char* file)
+{
+    int error = 0;
+    dogecoin_bool created = false;
+    dogecoin_wallet* wallet = dogecoin_wallet_new_ts(ctx);
+    if (!wallet) return NULL;
+    const char* target_file = file;
+    if (!target_file || target_file[0] == '\0') {
+        target_file = wallet->filename[0] ? wallet->filename : "wallet.db";
+    }
+    wallet_lock(wallet);
+    dogecoin_bool ok = dogecoin_wallet_load(wallet, target_file, &error, &created, false);
+    wallet_unlock(wallet);
+    if (!ok) {
+        dogecoin_wallet_free_ts(wallet);
+        return NULL;
+    }
+    return wallet;
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+void dogecoin_wallet_free_ts(dogecoin_wallet* wallet)
+{
+    dogecoin_wallet_free(wallet);
 }
 
 void dogecoin_wallet_scrape_utxos(dogecoin_wallet* wallet, dogecoin_wtx* wtx) {
@@ -1081,6 +1187,16 @@ dogecoin_bool dogecoin_wallet_flush(dogecoin_wallet* wallet)
     return true;
 }
 
+/* THREAD-SAFE variant - uses internal mutex */
+int dogecoin_wallet_save_ts(dogecoin_wallet* wallet)
+{
+    if (!wallet) return false;
+    wallet_lock(wallet);
+    dogecoin_bool ok = dogecoin_wallet_flush(wallet);
+    wallet_unlock(wallet);
+    return ok ? true : false;
+}
+
 dogecoin_bool wallet_write_record(dogecoin_wallet *wallet, const cstring* record, uint8_t record_type) {
     // write record magic
     if (fwrite(file_rec_magic, 4, 1, wallet->dbfile) != 1) return false;
@@ -1208,6 +1324,69 @@ dogecoin_wallet_addr* dogecoin_wallet_next_bip44_addr(dogecoin_wallet* wallet)
     wallet->next_childindex++;
 
     return waddr;
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+int dogecoin_wallet_get_address_ts(dogecoin_wallet* wallet, char* address, size_t len, uint32_t account, uint32_t index, dogecoin_bool change)
+{
+    if (!wallet || !wallet->masterkey || !address || len < P2PKHLEN) return false;
+    dogecoin_hdnode* hdnode = NULL;
+    dogecoin_hdnode* bip44_key = NULL;
+    int ret = false;
+    wallet_lock(wallet);
+    hdnode = dogecoin_hdnode_copy(wallet->masterkey);
+    bip44_key = dogecoin_hdnode_new();
+    if (hdnode && bip44_key) {
+        char keypath[BIP44_KEY_PATH_MAX_LENGTH + 1] = "";
+        char* change_level = change ? BIP44_CHANGE_INTERNAL : BIP44_CHANGE_EXTERNAL;
+        if (derive_bip44_extended_key(hdnode, &account, &index, change_level, NULL, false, keypath, bip44_key) == 0) {
+            dogecoin_hdnode_get_p2pkh_address(bip44_key, wallet->chain, address, len);
+            ret = true;
+        }
+    }
+    if (bip44_key) dogecoin_hdnode_free(bip44_key);
+    if (hdnode) dogecoin_hdnode_free(hdnode);
+    wallet_unlock(wallet);
+    return ret;
+}
+
+/* THREAD-SAFE variant - uses internal mutex */
+int dogecoin_wallet_add_hd_account_ts(dogecoin_wallet* wallet, uint32_t account)
+{
+    if (!wallet || !wallet->masterkey) return false;
+    wallet_lock(wallet);
+    dogecoin_wallet_addr* waddr = dogecoin_wallet_addr_new();
+    dogecoin_hdnode* hdnode = dogecoin_hdnode_copy(wallet->masterkey);
+    dogecoin_hdnode* bip44_key = dogecoin_hdnode_new();
+    uint32_t index = wallet->next_childindex;
+    int ret = false;
+    dogecoin_bool added_to_wallet = false;
+    if (waddr && hdnode && bip44_key) {
+        char keypath[BIP44_KEY_PATH_MAX_LENGTH + 1] = "";
+        char* change_level = BIP44_CHANGE_EXTERNAL;
+        if (derive_bip44_extended_key(hdnode, &account, &index, change_level, NULL, false, keypath, bip44_key) == 0) {
+            dogecoin_hdnode_get_hash160(bip44_key, waddr->pubkeyhash);
+            waddr->childindex = wallet->next_childindex;
+            void* tree_pos = dogecoin_btree_tsearch(waddr, &wallet->waddr_rbtree, dogecoin_wallet_addr_compare);
+            if (tree_pos) {
+                vector_add(wallet->waddr_vector, waddr);
+                added_to_wallet = true;
+                cstring* record = cstr_new_sz(256);
+                dogecoin_wallet_addr_serialize(record, wallet->chain, waddr);
+                if (wallet_write_record(wallet, record, WALLET_DB_REC_TYPE_ADDR)) {
+                    dogecoin_file_commit(wallet->dbfile);
+                    wallet->next_childindex++;
+                    ret = true;
+                }
+                cstr_free(record, true);
+            }
+        }
+    }
+    if (!ret && waddr && !added_to_wallet) dogecoin_wallet_addr_free(waddr);
+    if (bip44_key) dogecoin_hdnode_free(bip44_key);
+    if (hdnode) dogecoin_hdnode_free(hdnode);
+    wallet_unlock(wallet);
+    return ret;
 }
 
 dogecoin_bool dogecoin_p2pkh_address_to_wallet_pubkeyhash(const char* address_in, dogecoin_wallet_addr* addr, dogecoin_wallet* wallet) {

--- a/test/context_tests.c
+++ b/test/context_tests.c
@@ -1,0 +1,74 @@
+/**********************************************************************
+ * Copyright (c) 2024-2026 The Dogecoin Foundation                   *
+ * Distributed under the MIT software license, see the accompanying   *
+ * file COPYING or http://www.opensource.org/licenses/mit-license.php.*
+ **********************************************************************/
+
+#include <string.h>
+
+#include <test/utest.h>
+#include <dogecoin/libdogecoin.h>
+
+void test_context_keypair_ex()
+{
+    dogecoin_context* ctx = dogecoin_context_new(false, false);
+    u_assert_true(ctx != NULL);
+    u_assert_str_eq(dogecoin_context_get_chainparams(ctx)->chainname, dogecoin_chainparams_main.chainname);
+    u_assert_true(dogecoin_context_get_transaction_context(ctx) != NULL);
+    u_assert_true(dogecoin_context_get_eckey_context(ctx) != NULL);
+    u_assert_true(dogecoin_context_get_ecc_context(ctx) != NULL);
+    u_assert_true(dogecoin_context_get_rng_state(ctx) != NULL);
+
+    size_t wif_size = 0;
+    size_t addr_size = 0;
+    u_assert_true(dogecoin_generate_keypair_ex(ctx, NULL, &wif_size, NULL, &addr_size));
+    u_assert_true(wif_size > 1);
+    u_assert_true(addr_size > 1);
+
+    char wif[PRIVKEYWIFLEN] = {0};
+    char addr[P2PKHLEN] = {0};
+    size_t wif_cap = sizeof(wif);
+    size_t addr_cap = sizeof(addr);
+    u_assert_true(dogecoin_generate_keypair_ex(ctx, wif, &wif_cap, addr, &addr_cap));
+    u_assert_true(strlen(wif) > 0);
+    u_assert_true(strlen(addr) > 0);
+    u_assert_int_eq(dogecoin_context_get_error_code(ctx), 0);
+
+    char tiny_wif[1] = {0};
+    char tiny_addr[1] = {0};
+    size_t tiny_wif_cap = sizeof(tiny_wif);
+    size_t tiny_addr_cap = sizeof(tiny_addr);
+    u_assert_true(!dogecoin_generate_keypair_ex(ctx, tiny_wif, &tiny_wif_cap, tiny_addr, &tiny_addr_cap));
+    u_assert_true(dogecoin_context_get_error_code(ctx) != 0);
+    u_assert_true(strlen(dogecoin_context_get_error(ctx)) > 0);
+
+    dogecoin_context_release(ctx);
+}
+
+void test_context_ts_refcount()
+{
+    /* A plain context is not tagged thread-safe. */
+    dogecoin_context* ctx = dogecoin_context_new(false, false);
+    u_assert_true(ctx != NULL);
+    u_assert_int_eq(dogecoin_ctx_is_thread_safe(ctx), 0);
+    dogecoin_context_release(ctx);
+
+    /* A _ts context is tagged thread-safe and is reference counted: each
+     * dogecoin_ctx_acquire must be balanced by a dogecoin_ctx_release, and the
+     * final release frees the context. */
+    dogecoin_ctx* ts = dogecoin_ctx_new_ts(false, false);
+    u_assert_true(ts != NULL);
+    u_assert_true(dogecoin_ctx_is_thread_safe(ts) != 0);
+
+    dogecoin_ctx_acquire(ts);
+    dogecoin_ctx_acquire(ts);
+    /* Two acquires => three outstanding references (new + 2). */
+    dogecoin_ctx_release(ts);
+    dogecoin_ctx_release(ts);
+
+    /* The context is still usable while a reference remains. */
+    u_assert_true(dogecoin_context_get_chainparams(ts) != NULL);
+
+    /* Final release frees it. */
+    dogecoin_ctx_release(ts);
+}

--- a/test/signmsg_tests.c
+++ b/test/signmsg_tests.c
@@ -63,3 +63,27 @@ void test_signmsg_ext() {
     dogecoin_free(key);
     dogecoin_free(sig);
 }
+
+void test_signmsg_ts_contexts() {
+    dogecoin_eckey_context* ctx1 = dogecoin_eckey_context_new();
+    dogecoin_eckey_context* ctx2 = dogecoin_eckey_context_new();
+    u_assert_true(ctx1 != NULL);
+    u_assert_true(ctx2 != NULL);
+
+    int key_id1 = start_key_ts(ctx1, false);
+    int key_id2 = start_key_ts(ctx2, false);
+    u_assert_int_eq(key_id1, 1);
+    u_assert_int_eq(key_id2, 1);
+
+    eckey* key1 = find_eckey_ts(ctx1, key_id1);
+    eckey* key2 = find_eckey_ts(ctx2, key_id2);
+    u_assert_true(key1 != NULL);
+    u_assert_true(key2 != NULL);
+
+    u_assert_true(key1 != key2);
+
+    remove_eckey_ts(ctx1, key1);
+    remove_eckey_ts(ctx2, key2);
+    dogecoin_eckey_context_free(ctx1);
+    dogecoin_eckey_context_free(ctx2);
+}

--- a/test/transaction_tests.c
+++ b/test/transaction_tests.c
@@ -14,16 +14,21 @@
 
 #include <dogecoin/address.h>
 #include <dogecoin/buffer.h>
+#include <dogecoin/ecc.h>
 #include <dogecoin/key.h>
 #include <dogecoin/koinu.h>
 #include <dogecoin/transaction.h>
 #include <dogecoin/tx.h>
 #include <dogecoin/utils.h>
+#include <dogecoin/wallet.h>
 #include <dogecoin/pqc_dilithium.h>
 #include <dogecoin/pqc_falcon.h>
 #include <dogecoin/pqc_carrier.h>
 #ifdef USE_RACCOON_G
 #include <dogecoin/pqc_raccoon.h>
+#endif
+#if !defined(_WIN32)
+#include <pthread.h>
 #endif
 
 /*
@@ -321,6 +326,54 @@ void test_transaction()
     u_assert_str_eq(raw_hexadecimal_transaction, expected_single_utxo_signed_transaction);
 
     // ----------------------------------------------------------------
+    // test the thread-safe index API (_ts variants) against a dedicated
+    // thread-safe transaction context. The working transaction is mutex-bearing
+    // (built via new_transaction_ts -> dogecoin_tx_new_ts), so add_utxo_ts /
+    // add_output_ts / finalize_transaction_ts exercise the underlying
+    // dogecoin_tx_add_input_ts / dogecoin_tx_add_output_ts / dogecoin_tx_finalize_ts
+    // primitives and must produce byte-identical output to the non-_ts path.
+    //
+    // Build the reference (unsigned) transaction through the non-_ts index API
+    // and snapshot it (utils_uint8_to_hex returns a shared static buffer, so the
+    // result must be copied before any further serialization overwrites it):
+
+    int ref_index = start_transaction();
+    u_assert_int_eq(add_utxo(ref_index, utxo_txid_from_tx_worth_10_dogecoin, utxo_previous_output_index_from_tx_worth_10_dogecoin), 1);
+    u_assert_int_eq(add_output(ref_index, external_p2pkh_address, "9.99887"), 1);
+    char* ref_finalized = finalize_transaction(ref_index, external_p2pkh_address, ".00113", "10.0", internal_p2pkh_address);
+    u_assert_not_null(ref_finalized);
+    char ref_unsigned_hex[512];
+    u_assert_true(strlen(ref_finalized) < sizeof(ref_unsigned_hex));
+    strcpy(ref_unsigned_hex, ref_finalized);
+    clear_transaction(ref_index);
+
+    // Build the same transaction through the thread-safe index API on its own context:
+    dogecoin_transaction_context* ts_ctx = dogecoin_transaction_context_new();
+    u_assert_not_null(ts_ctx);
+
+    int ts_index = start_transaction_ts(ts_ctx);
+
+    // add the single 10 dogecoin input through the thread-safe primitive:
+    u_assert_int_eq(add_utxo_ts(ts_ctx, ts_index, utxo_txid_from_tx_worth_10_dogecoin, utxo_previous_output_index_from_tx_worth_10_dogecoin), 1);
+
+    // add the output through the thread-safe primitive:
+    u_assert_int_eq(add_output_ts(ts_ctx, ts_index, external_p2pkh_address, "9.99887"), 1);
+
+    // finalize through the thread-safe primitive and confirm identical bytes:
+    char* ts_finalized = finalize_transaction_ts(ts_ctx, ts_index, external_p2pkh_address, ".00113", "10.0", internal_p2pkh_address);
+    u_assert_not_null(ts_finalized);
+    u_assert_str_eq(ts_finalized, ref_unsigned_hex);
+
+    // get_raw_transaction_ts must return the same serialized hex:
+    u_assert_str_eq(get_raw_transaction_ts(ts_ctx, ts_index), ref_unsigned_hex);
+
+    // clear_transaction_ts removes the entry from the thread-safe context:
+    clear_transaction_ts(ts_ctx, ts_index);
+    u_assert_is_null(get_raw_transaction_ts(ts_ctx, ts_index));
+
+    dogecoin_transaction_context_free(ts_ctx);
+
+    // ----------------------------------------------------------------
     // test store_raw_transaction:
 
     int working_transaction_index2 = store_raw_transaction(raw_hexadecimal_transaction);
@@ -607,6 +660,9 @@ void test_transaction()
     u_assert_true(sign_transaction_w_privkey_ex(working_transaction_index, private_key_wif, buf5, sizeof(buf5)));
     u_assert_str_eq(buf5, get_raw_transaction(working_transaction_index));
 
+    // cleanup large transaction context entries (important for leak checks)
+    remove_all();
+
     // ----------------------------------------------------------------
     // optional Falcon-512 OP_RETURN commit test (only when built with liboqs)
 #ifdef USE_LIBOQS
@@ -761,3 +817,160 @@ void test_transaction()
     cstr_free(carrier_redeem, true);
 #endif
 }
+
+void test_transaction_ts_contexts() {
+    dogecoin_transaction_context* ctx1 = dogecoin_transaction_context_new();
+    dogecoin_transaction_context* ctx2 = dogecoin_transaction_context_new();
+    u_assert_true(ctx1 != NULL);
+    u_assert_true(ctx2 != NULL);
+
+    int tx1 = start_transaction_ts(ctx1);
+    int tx2 = start_transaction_ts(ctx2);
+    u_assert_int_eq(tx1, 1);
+    u_assert_int_eq(tx2, 1);
+
+    working_transaction* wtx1 = find_transaction_ts(ctx1, tx1);
+    working_transaction* wtx2 = find_transaction_ts(ctx2, tx2);
+    u_assert_true(wtx1 != NULL);
+    u_assert_true(wtx2 != NULL);
+
+    u_assert_true(wtx1 != wtx2);
+
+    remove_transaction_ts(ctx1, wtx1);
+    remove_transaction_ts(ctx2, wtx2);
+    dogecoin_transaction_context_free(ctx1);
+    dogecoin_transaction_context_free(ctx2);
+}
+
+void test_transaction_ts_wrappers() {
+    dogecoin_tx* tx = dogecoin_tx_new_ts();
+    u_assert_not_null(tx);
+
+    dogecoin_tx_in* tx_in = dogecoin_tx_in_new();
+    u_assert_not_null(tx_in);
+    dogecoin_hash_clear(tx_in->prevout.hash);
+    tx_in->prevout.n = 0;
+    tx_in->script_sig = cstr_new_sz(32);
+    /* P2PKH script template used by legacy transaction test vectors. */
+    uint8_t script_raw[25] = {
+        0x76, 0xa9, 0x14, 0xd8, 0xc4, 0x3e, 0x6f, 0x68, 0xca, 0x4e,
+        0xa1, 0xe9, 0xb9, 0x3d, 0xa2, 0xd1, 0xe3, 0xa9, 0x51, 0x18,
+        0xfa, 0x4a, 0x7c, 0x88, 0xac
+    };
+    cstr_append_buf(tx_in->script_sig, script_raw, sizeof(script_raw));
+    u_assert_int_eq(dogecoin_tx_add_input_ts(tx, tx_in), true);
+    dogecoin_tx_in_free(tx_in);
+
+    dogecoin_tx_out* tx_out = dogecoin_tx_out_new();
+    u_assert_not_null(tx_out);
+    tx_out->value = 1000;
+    tx_out->script_pubkey = cstr_new_sz(1);
+    cstr_append_c(tx_out->script_pubkey, OP_TRUE);
+    u_assert_int_eq(dogecoin_tx_add_output_ts(tx, tx_out), true);
+    dogecoin_tx_out_free(tx_out);
+
+    dogecoin_ctx* ctx = dogecoin_ctx_new_ts(true, false);
+    u_assert_not_null(ctx);
+    dogecoin_wallet* wallet = dogecoin_wallet_load_ts(ctx, "tx_ts_wallet.db");
+    u_assert_not_null(wallet);
+
+    uint8_t seed[32];
+    dogecoin_mem_zero(seed, sizeof(seed));
+    seed[0] = 0x24;
+    dogecoin_hdnode node;
+    u_assert_true(dogecoin_hdnode_from_seed(seed, sizeof(seed), &node));
+    dogecoin_wallet_set_master_key_copy(wallet, &node);
+
+    int sign_rc = dogecoin_tx_sign_ts(tx, wallet, NULL);
+    u_assert_int_eq(sign_rc, true);
+    u_assert_int_eq(dogecoin_tx_finalize_ts(tx), true);
+
+    dogecoin_wallet_free_ts(wallet);
+    dogecoin_ctx_release(ctx);
+    dogecoin_tx_free_ts(tx);
+    remove("tx_ts_wallet.db");
+}
+
+#if !defined(_WIN32)
+typedef struct tx_ts_stress_args_ {
+    dogecoin_wallet* wallet;
+    uint32_t id;
+    dogecoin_bool ok;
+} tx_ts_stress_args;
+
+static void* tx_ts_stress_worker(void* user)
+{
+    tx_ts_stress_args* args = (tx_ts_stress_args*)user;
+    args->ok = true;
+    dogecoin_ecc_start();
+    /* 4 iterations keeps the test fast under QEMU arm emulation */
+    for (uint32_t i = 0; i < 4; i++) {
+        dogecoin_tx* tx = dogecoin_tx_new_ts();
+        if (!tx) {
+            args->ok = false;
+            break;
+        }
+
+        dogecoin_tx_in* tx_in = dogecoin_tx_in_new();
+        dogecoin_hash_clear(tx_in->prevout.hash);
+        tx_in->prevout.n = args->id * 1000 + i;
+        tx_in->script_sig = cstr_new_sz(25);
+        /* P2PKH script template reused from existing transaction test vectors. */
+        uint8_t script_raw[25] = {
+            0x76, 0xa9, 0x14, 0xd8, 0xc4, 0x3e, 0x6f, 0x68, 0xca, 0x4e,
+            0xa1, 0xe9, 0xb9, 0x3d, 0xa2, 0xd1, 0xe3, 0xa9, 0x51, 0x18,
+            0xfa, 0x4a, 0x7c, 0x88, 0xac
+        };
+        cstr_append_buf(tx_in->script_sig, script_raw, sizeof(script_raw));
+        if (!dogecoin_tx_add_input_ts(tx, tx_in)) args->ok = false;
+        dogecoin_tx_in_free(tx_in);
+
+        dogecoin_tx_out* tx_out = dogecoin_tx_out_new();
+        tx_out->value = 1000 + i;
+        tx_out->script_pubkey = cstr_new_sz(1);
+        cstr_append_c(tx_out->script_pubkey, OP_TRUE);
+        if (!dogecoin_tx_add_output_ts(tx, tx_out)) args->ok = false;
+        dogecoin_tx_out_free(tx_out);
+
+        if (args->ok && !dogecoin_tx_sign_ts(tx, args->wallet, NULL)) args->ok = false;
+        if (args->ok && !dogecoin_tx_finalize_ts(tx)) args->ok = false;
+        dogecoin_tx_free_ts(tx);
+
+        if (!args->ok) break;
+    }
+    dogecoin_ecc_stop();
+    return NULL;
+}
+
+void test_transaction_ts_multithread_stress()
+{
+    dogecoin_ctx* ctx = dogecoin_ctx_new_ts(true, false);
+    u_assert_not_null(ctx);
+    dogecoin_wallet* wallet = dogecoin_wallet_load_ts(ctx, "tx_ts_wallet_stress.db");
+    u_assert_not_null(wallet);
+
+    uint8_t seed[32];
+    dogecoin_mem_zero(seed, sizeof(seed));
+    seed[0] = 0x39;
+    dogecoin_hdnode node;
+    u_assert_true(dogecoin_hdnode_from_seed(seed, sizeof(seed), &node));
+    dogecoin_wallet_set_master_key_copy(wallet, &node);
+
+    pthread_t threads[4];
+    tx_ts_stress_args args[4];
+    for (uint32_t i = 0; i < 4; i++) {
+        args[i].wallet = wallet;
+        args[i].id = i;
+        args[i].ok = false;
+        u_assert_int_eq(pthread_create(&threads[i], NULL, tx_ts_stress_worker, &args[i]), 0);
+    }
+    for (uint32_t i = 0; i < 4; i++) {
+        pthread_join(threads[i], NULL);
+        u_assert_true(args[i].ok);
+    }
+
+    dogecoin_wallet_free_ts(wallet);
+    dogecoin_ctx_release(ctx);
+    remove("tx_ts_wallet_stress.db");
+}
+#endif

--- a/test/unittester.c
+++ b/test/unittester.c
@@ -52,6 +52,8 @@ extern void test_cstr();
 extern void test_ecc();
 extern void test_hash();
 extern void test_key();
+extern void test_context_keypair_ex();
+extern void test_context_ts_refcount();
 extern void test_koinu();
 extern void test_memory();
 extern void test_moon();
@@ -68,8 +70,14 @@ extern void test_sha_hmac();
 extern void test_signmsg();
 extern void test_smpv();
 extern void test_signmsg_ext();
+extern void test_signmsg_ts_contexts();
 extern void test_tpm();
 extern void test_transaction();
+extern void test_transaction_ts_contexts();
+extern void test_transaction_ts_wrappers();
+#if !defined(_WIN32)
+extern void test_transaction_ts_multithread_stress();
+#endif
 extern void test_validation();
 extern void test_tx_serialization();
 extern void test_tx_sighash();
@@ -117,6 +125,10 @@ extern void test_examples();
 extern void test_wallet_basics();
 extern void test_wallet();
 extern void test_wallet_reorg_utxo_update();
+extern void test_wallet_ts_wrappers();
+#if !defined(_WIN32)
+extern void test_wallet_ts_multithread_stress();
+#endif
 extern void test_wallet_balance_accounts_for_spends();
 #endif
 
@@ -162,6 +174,8 @@ int main()
     u_run_test(test_ecc);
     u_run_test(test_hash);
     u_run_test(test_key);
+    u_run_test(test_context_keypair_ex);
+    u_run_test(test_context_ts_refcount);
     u_run_test(test_koinu);
     u_run_test(test_memory);
     u_run_test(test_moon);
@@ -177,11 +191,19 @@ int main()
     u_run_test(test_sha_hmac);
     u_run_test(test_signmsg);
     u_run_test(test_signmsg_ext);
+    u_run_test(test_signmsg_ts_contexts);
     u_run_test(test_smpv);
 #ifndef USE_OPTEE // TPM is not supported in OPTEE
     u_run_test(test_tpm);
 #endif
     u_run_test(test_transaction);
+    u_run_test(test_transaction_ts_contexts);
+#ifndef USE_OPTEE
+    u_run_test(test_transaction_ts_wrappers);
+#if !defined(_WIN32)
+    u_run_test(test_transaction_ts_multithread_stress);
+#endif
+#endif
     u_run_test(test_validation);
     u_run_test(test_tx_serialization);
     u_run_test(test_invalid_tx_deser);
@@ -229,6 +251,12 @@ int main()
     u_run_test(test_wallet_basics);
     u_run_test(test_wallet);
     u_run_test(test_wallet_reorg_utxo_update);
+#ifndef USE_OPTEE
+    u_run_test(test_wallet_ts_wrappers);
+#if !defined(_WIN32)
+    u_run_test(test_wallet_ts_multithread_stress);
+#endif
+#endif
     u_run_test(test_wallet_balance_accounts_for_spends);
 #endif
 

--- a/test/wallet_tests.c
+++ b/test/wallet_tests.c
@@ -24,10 +24,15 @@ static const char *wallettmpfile = "/tmp/dummy";
 #include <logdb/logdb.h>
 
 #include <dogecoin/base58.h>
+#include <dogecoin/ecc.h>
 #include <dogecoin/utils.h>
 #include <dogecoin/wallet.h>
 #include <dogecoin/script.h>
+#if !defined(_WIN32)
+#include <pthread.h>
+#endif
 #define is_spent(x) (((dogecoin_utxo*)x)->spendable == false)
+
 
 /* this are the tx_valid test vectors from Bitcoin Core 0.15, run through Bitcoin Core's SignatureHash function */
 static const char * wallet_txns[] = {
@@ -305,23 +310,118 @@ void test_wallet_reorg_utxo_update() {
             u_assert_int_eq(u->height, 100);
         }
     }
-   dogecoin_wtx* wtx_new = dogecoin_wallet_wtx_new();
-   dogecoin_tx_copy(wtx_new->tx, tx);
-   wtx_new->height = 105;
-   dogecoin_wallet_scrape_utxos(wallet, wtx_new);
-   HASH_ITER(hh, utxos, u, tmp) {
+    dogecoin_wtx* wtx_new = dogecoin_wallet_wtx_new();
+    dogecoin_tx_copy(wtx_new->tx, tx);
+    wtx_new->height = 105;
+    dogecoin_wallet_scrape_utxos(wallet, wtx_new);
+    HASH_ITER(hh, utxos, u, tmp) {
         if (!is_spent(u)) {
             u_assert_int_eq(u->height, 105);
         }
     }
 
-    dogecoin_wallet_flush(wallet);
+    dogecoin_wallet_wtx_free(wtx);
     dogecoin_wallet_wtx_free(wtx_new);
+    dogecoin_wallet_flush(wallet);
     dogecoin_wallet_free(wallet);
     dogecoin_hdnode_free(node);
     remove_all_utxos();
 }
 
+void test_wallet_ts_wrappers()
+{
+    unlink(wallettmpfile);
+    dogecoin_ctx* ctx = dogecoin_ctx_new_ts(false, false);
+    u_assert_not_null(ctx);
+
+    dogecoin_wallet* wallet = dogecoin_wallet_load_ts(ctx, wallettmpfile);
+    u_assert_not_null(wallet);
+
+    uint8_t seed[32];
+    dogecoin_mem_zero(seed, sizeof(seed));
+    seed[0] = 0x42;
+    dogecoin_hdnode node;
+    u_assert_true(dogecoin_hdnode_from_seed(seed, sizeof(seed), &node));
+    dogecoin_wallet_set_master_key_copy(wallet, &node);
+
+    u_assert_int_eq(dogecoin_wallet_add_hd_account_ts(wallet, 0), true);
+    char addr[P2PKHLEN];
+    dogecoin_mem_zero(addr, sizeof(addr));
+    u_assert_int_eq(dogecoin_wallet_get_address_ts(wallet, addr, sizeof(addr), 0, 0, false), true);
+    u_assert_true(strlen(addr) > 0);
+    u_assert_int_eq(dogecoin_wallet_save_ts(wallet), true);
+    dogecoin_wallet_free_ts(wallet);
+
+    dogecoin_wallet* wallet2 = dogecoin_wallet_load_ts(ctx, wallettmpfile);
+    u_assert_not_null(wallet2);
+    dogecoin_wallet_free_ts(wallet2);
+    dogecoin_ctx_release(ctx);
+}
+
+#if !defined(_WIN32)
+typedef struct wallet_ts_stress_args_ {
+    dogecoin_wallet* wallet;
+    uint32_t index_base;
+    dogecoin_bool ok;
+} wallet_ts_stress_args;
+
+static void* wallet_ts_stress_worker(void* user) {
+    wallet_ts_stress_args* args = (wallet_ts_stress_args*)user;
+    args->ok = true;
+    dogecoin_ecc_start();
+    /* 4 iterations keeps the test fast under QEMU arm emulation */
+    for (uint32_t i = 0; i < 4; i++) {
+        char address[P2PKHLEN];
+        dogecoin_mem_zero(address, sizeof(address));
+        if (!dogecoin_wallet_get_address_ts(args->wallet, address, sizeof(address), 0, args->index_base + i, false)) {
+            args->ok = false;
+            break;
+        }
+        if (strlen(address) == 0) {
+            args->ok = false;
+            break;
+        }
+    }
+    dogecoin_ecc_stop();
+    return NULL;
+}
+
+void test_wallet_ts_multithread_stress()
+{
+    unlink(wallettmpfile);
+    dogecoin_ctx* ctx = dogecoin_ctx_new_ts(false, false);
+    u_assert_not_null(ctx);
+
+    dogecoin_wallet* wallet = dogecoin_wallet_load_ts(ctx, wallettmpfile);
+    u_assert_not_null(wallet);
+
+    uint8_t seed[32];
+    dogecoin_mem_zero(seed, sizeof(seed));
+    seed[0] = 0x77;
+    dogecoin_hdnode node;
+    u_assert_true(dogecoin_hdnode_from_seed(seed, sizeof(seed), &node));
+    dogecoin_wallet_set_master_key_copy(wallet, &node);
+
+    u_assert_int_eq(dogecoin_wallet_add_hd_account_ts(wallet, 0), true);
+
+    pthread_t threads[4];
+    wallet_ts_stress_args args[4];
+    for (uint32_t i = 0; i < 4; i++) {
+        args[i].wallet = wallet;
+        args[i].index_base = i * 64;
+        args[i].ok = false;
+        u_assert_int_eq(pthread_create(&threads[i], NULL, wallet_ts_stress_worker, &args[i]), 0);
+    }
+    for (uint32_t i = 0; i < 4; i++) {
+        pthread_join(threads[i], NULL);
+        u_assert_true(args[i].ok);
+    }
+
+    u_assert_int_eq(dogecoin_wallet_save_ts(wallet), true);
+    dogecoin_wallet_free_ts(wallet);
+    dogecoin_ctx_release(ctx);
+}
+#endif
 void test_wallet_balance_accounts_for_spends() {
     const dogecoin_chainparams* chain = &dogecoin_chainparams_main;
 

--- a/tooltests.py
+++ b/tooltests.py
@@ -40,24 +40,30 @@ commands2.append(["?", 1])
 commands2.append(["-t -s 8 -d 0200000001554fb2f9", 1])
 commands2.append(["-t -s 5 -i 127.0.0.1:44556 0200000001554fb2f97f8fe299bf01004c70ec1930bc3c51fe162d1f81b18089e4f7cae470000000006a47304402207f5af3a9724be2946741e15b89bd2c989c9c20a0dfb519cb14b4efdaad945dc502206507ec7a3ba91be7794312961294c7a09a7bc693d918ab5a93712ff8576995fc012103caef57fae78ec425f5ff99d805fddd2417f3bfa7c7b0ec3b6b860cf6cc0e1d99ffffffff0100c63e05000000001976a91415e7469e21938db38e943abd7a2c1073c00e0edd88ac00000000", 0])
 
-baseCommand = "./such"
-baseCommand2 = "./sendtx"
+# Exercise both the plain CLI binaries and, when present, their thread-safe
+# (`_ts`) counterparts so CI covers the thread-safe library routing. The `_ts`
+# binaries are built from the same sources with -DDOGECOIN_TS and route through
+# the matching `_ts` library API (see include/dogecoin/threadsafe.h).
+suchVariants = [v for v in ["./such", "./such_ts"] if os.path.isfile(v)]
+sendtxVariants = [v for v in ["./sendtx", "./sendtx_ts"] if os.path.isfile(v)]
 if valgrind == True:
-    baseCommand = "valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes  --error-exitcode=1 "+baseCommand
-    baseCommand2 = "valgrind --track-origins=yes --error-exitcode=1 --leak-check=full "+baseCommand2
+    suchVariants = ["valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes  --error-exitcode=1 "+v for v in suchVariants]
+    sendtxVariants = ["valgrind --track-origins=yes --error-exitcode=1 --leak-check=full "+v for v in sendtxVariants]
 
 errored = False
-for cmd in commands:
-    retcode = call(baseCommand+" "+cmd[0], shell=True)
-    if retcode != cmd[1]:
-        print("ERROR during "+cmd[0])
-        sys.exit(os.EX_DATAERR)
+for baseCommand in suchVariants:
+    for cmd in commands:
+        retcode = call(baseCommand+" "+cmd[0], shell=True)
+        if retcode != cmd[1]:
+            print("ERROR during "+baseCommand+" "+cmd[0])
+            sys.exit(os.EX_DATAERR)
 
 errored = False
-for cmd in commands2:
-    retcode = call(baseCommand2+" "+cmd[0], shell=True)
-    if retcode != cmd[1]:
-        print("ERROR during "+cmd[0])
-        sys.exit(os.EX_DATAERR)
+for baseCommand2 in sendtxVariants:
+    for cmd in commands2:
+        retcode = call(baseCommand2+" "+cmd[0], shell=True)
+        if retcode != cmd[1]:
+            print("ERROR during "+baseCommand2+" "+cmd[0])
+            sys.exit(os.EX_DATAERR)
 
 sys.exit(os.EX_OK)


### PR DESCRIPTION
Temporary — diagnosing which dogecoin_context_new path returns NULL on the OP-TEE/enclave/aarch64 legs. Will close after reading CI.